### PR TITLE
feat(cv): clean up R2 files on CV update, delete, and account deletion

### DIFF
--- a/prisma/migrations/20260316233929_add_r2key_to_master_cv/migration.sql
+++ b/prisma/migrations/20260316233929_add_r2key_to_master_cv/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MasterCV" ADD COLUMN     "r2Key" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,7 @@ model MasterCV {
   rawText          String   @db.Text
   originalFileName String
   originalFileUrl  String
+  r2Key            String?
   parsedSections   Json?
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -2,7 +2,7 @@ import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { deleteFileFromR2 } from "@/lib/r2";
+import { deleteFileFromR2, extractR2KeyFromUrl } from "@/lib/r2";
 
 export async function GET() {
 	const session = await auth.api.getSession({ headers: await headers() });
@@ -36,15 +36,16 @@ export async function DELETE() {
 
 	const masterCV = await prisma.masterCV.findUnique({
 		where: { userId: session.user.id },
-		select: { id: true, r2Key: true },
+		select: { id: true, r2Key: true, originalFileUrl: true },
 	});
 
 	if (!masterCV) {
 		return NextResponse.json({ error: "No CV found" }, { status: 404 });
 	}
 
-	if (masterCV.r2Key) {
-		await deleteFileFromR2(masterCV.r2Key);
+	const r2Key = masterCV.r2Key ?? extractR2KeyFromUrl(masterCV.originalFileUrl);
+	if (r2Key) {
+		await deleteFileFromR2(r2Key);
 	}
 
 	await prisma.masterCV.delete({ where: { id: masterCV.id } });

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -2,6 +2,7 @@ import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { deleteFileFromR2 } from "@/lib/r2";
 
 export async function GET() {
 	const session = await auth.api.getSession({ headers: await headers() });
@@ -25,4 +26,28 @@ export async function GET() {
 		createdAt: masterCV.createdAt,
 		updatedAt: masterCV.updatedAt,
 	});
+}
+
+export async function DELETE() {
+	const session = await auth.api.getSession({ headers: await headers() });
+	if (!session) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const masterCV = await prisma.masterCV.findUnique({
+		where: { userId: session.user.id },
+		select: { id: true, r2Key: true },
+	});
+
+	if (!masterCV) {
+		return NextResponse.json({ error: "No CV found" }, { status: 404 });
+	}
+
+	if (masterCV.r2Key) {
+		await deleteFileFromR2(masterCV.r2Key);
+	}
+
+	await prisma.masterCV.delete({ where: { id: masterCV.id } });
+
+	return NextResponse.json({ success: true });
 }

--- a/src/app/api/cv/upload/route.ts
+++ b/src/app/api/cv/upload/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@/lib/auth";
 import { extractText } from "@/lib/cv-parser";
 import { parseCV } from "@/lib/gemini";
 import { prisma } from "@/lib/prisma";
-import { deleteFileFromR2, getFileFromR2, getR2PublicUrl } from "@/lib/r2";
+import { deleteFileFromR2, extractR2KeyFromUrl, getFileFromR2, getR2PublicUrl } from "@/lib/r2";
 import { cvUploadSchema } from "@/lib/validations";
 
 export async function POST(request: Request) {
@@ -25,14 +25,11 @@ export async function POST(request: Request) {
 	const { r2Key, fileName, contentType } = parsed.data;
 
 	try {
-		// 1. Delete old R2 file if replacing
+		// 1. Get existing CV info before replacing
 		const existingCV = await prisma.masterCV.findUnique({
 			where: { userId: session.user.id },
-			select: { r2Key: true },
+			select: { r2Key: true, originalFileUrl: true },
 		});
-		if (existingCV?.r2Key) {
-			await deleteFileFromR2(existingCV.r2Key);
-		}
 
 		// 2. Fetch new file from R2
 		const buffer = await getFileFromR2(r2Key);
@@ -57,6 +54,12 @@ export async function POST(request: Request) {
 			create: { userId: session.user.id, ...cvData },
 			update: cvData,
 		});
+
+		// 6. Delete old R2 file only after upsert succeeds
+		const oldR2Key = existingCV?.r2Key ?? extractR2KeyFromUrl(existingCV?.originalFileUrl);
+		if (oldR2Key && oldR2Key !== r2Key) {
+			await deleteFileFromR2(oldR2Key);
+		}
 
 		return NextResponse.json({
 			id: masterCV.id,

--- a/src/app/api/cv/upload/route.ts
+++ b/src/app/api/cv/upload/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@/lib/auth";
 import { extractText } from "@/lib/cv-parser";
 import { parseCV } from "@/lib/gemini";
 import { prisma } from "@/lib/prisma";
-import { getFileFromR2, getR2PublicUrl } from "@/lib/r2";
+import { deleteFileFromR2, getFileFromR2, getR2PublicUrl } from "@/lib/r2";
 import { cvUploadSchema } from "@/lib/validations";
 
 export async function POST(request: Request) {
@@ -25,20 +25,30 @@ export async function POST(request: Request) {
 	const { r2Key, fileName, contentType } = parsed.data;
 
 	try {
-		// 1. Fetch file from R2
+		// 1. Delete old R2 file if replacing
+		const existingCV = await prisma.masterCV.findUnique({
+			where: { userId: session.user.id },
+			select: { r2Key: true },
+		});
+		if (existingCV?.r2Key) {
+			await deleteFileFromR2(existingCV.r2Key);
+		}
+
+		// 2. Fetch new file from R2
 		const buffer = await getFileFromR2(r2Key);
 
-		// 2. Extract raw text
+		// 3. Extract raw text
 		const rawText = await extractText(buffer, contentType);
 
-		// 3. Parse CV with Gemini AI
+		// 4. Parse CV with Gemini AI
 		const parsedSections = await parseCV(rawText);
 
-		// 4. Upsert MasterCV (one-to-one: replace if exists)
+		// 5. Upsert MasterCV (one-to-one: replace if exists)
 		const cvData = {
 			rawText,
 			originalFileName: fileName,
 			originalFileUrl: getR2PublicUrl(r2Key),
+			r2Key,
 			parsedSections: JSON.parse(JSON.stringify(parsedSections)),
 		};
 

--- a/src/app/api/settings/account/route.ts
+++ b/src/app/api/settings/account/route.ts
@@ -2,11 +2,21 @@ import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { deleteFileFromR2 } from "@/lib/r2";
 
 export async function DELETE() {
 	const session = await auth.api.getSession({ headers: await headers() });
 	if (!session) {
 		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	// Clean up R2 files before deleting user
+	const masterCV = await prisma.masterCV.findUnique({
+		where: { userId: session.user.id },
+		select: { r2Key: true },
+	});
+	if (masterCV?.r2Key) {
+		await deleteFileFromR2(masterCV.r2Key);
 	}
 
 	// Cascading delete: User model has onDelete: Cascade on all relations

--- a/src/app/api/settings/account/route.ts
+++ b/src/app/api/settings/account/route.ts
@@ -2,7 +2,7 @@ import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { deleteFileFromR2 } from "@/lib/r2";
+import { deleteFileFromR2, extractR2KeyFromUrl } from "@/lib/r2";
 
 export async function DELETE() {
 	const session = await auth.api.getSession({ headers: await headers() });
@@ -13,10 +13,11 @@ export async function DELETE() {
 	// Clean up R2 files before deleting user
 	const masterCV = await prisma.masterCV.findUnique({
 		where: { userId: session.user.id },
-		select: { r2Key: true },
+		select: { r2Key: true, originalFileUrl: true },
 	});
-	if (masterCV?.r2Key) {
-		await deleteFileFromR2(masterCV.r2Key);
+	const r2Key = masterCV?.r2Key ?? extractR2KeyFromUrl(masterCV?.originalFileUrl);
+	if (r2Key) {
+		await deleteFileFromR2(r2Key);
 	}
 
 	// Cascading delete: User model has onDelete: Cascade on all relations

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -49,3 +49,10 @@ export async function deleteFileFromR2(key: string) {
 export function getR2PublicUrl(key: string) {
 	return `${process.env.CLOUDFLARE_R2_ENDPOINT}/${BUCKET}/${key}`;
 }
+
+export function extractR2KeyFromUrl(url: string | null | undefined): string | null {
+	if (!url) return null;
+	const prefix = `${process.env.CLOUDFLARE_R2_ENDPOINT}/${BUCKET}/`;
+	if (!url.startsWith(prefix)) return null;
+	return url.slice(prefix.length);
+}


### PR DESCRIPTION
## Summary
- Add `r2Key` field to `MasterCV` model to track which file is stored in R2
- Delete old R2 file when user uploads a replacement CV
- Add `DELETE /api/cv` endpoint to remove CV and its R2 file
- Clean up R2 files before cascading user account deletion

Previously, old CV files were left orphaned in R2 on update, and there was no way to delete a CV. Now R2 storage is cleaned up in all scenarios: CV update, CV delete, and account deletion.

## Test plan
- [ ] Upload a CV, verify `r2Key` is stored in the database
- [ ] Upload a replacement CV, verify the old file is removed from R2
- [ ] Delete a CV via the API, verify R2 file and DB record are removed
- [ ] Delete a user account, verify the associated R2 file is cleaned up