### PR TITLE
fix(build): run prisma generate before build and on postinstall

### DIFF
--- a/.github/workflows/install-build.yml
+++ b/.github/workflows/install-build.yml
@@ -1,0 +1,33 @@
+name: Install and Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  install-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm --ignore-workspace install --frozen-lockfile
+
+      - name: Build
+        run: pnpm --ignore-workspace build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "prisma generate && next build",
+    "postinstall": "prisma generate",
     "start": "next start",
     "lint": "biome lint ./src",
     "format": "biome format --write ./src",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "prisma generate && next build",
-    "postinstall": "prisma generate",
+    "postinstall": "node -e \"const cp=require('node:child_process');const has=cp.spawnSync(process.platform==='win32'?'where':'which',['prisma'],{stdio:'ignore'}).status===0;if(!has){console.log('Skipping prisma generate: Prisma CLI not installed');process.exit(0);}cp.execSync('prisma generate',{stdio:'inherit'});\"",
     "start": "next start",
     "lint": "biome lint ./src",
     "format": "biome format --write ./src",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "prisma generate && next build",
-    "postinstall": "node -e \"const cp=require('node:child_process');const has=cp.spawnSync(process.platform==='win32'?'where':'which',['prisma'],{stdio:'ignore'}).status===0;if(!has){console.log('Skipping prisma generate: Prisma CLI not installed');process.exit(0);}cp.execSync('prisma generate',{stdio:'inherit'});\"",
+    "postinstall": "node -e \"const cp=require('node:child_process');try{cp.execSync('prisma --version',{stdio:'ignore'});}catch(e){if(e?.code==='ENOENT'||e?.status===127){console.log('Skipping prisma generate: Prisma CLI not installed');process.exit(0);}throw e;}cp.execSync('prisma generate',{stdio:'inherit'});\"",
     "start": "next start",
     "lint": "biome lint ./src",
     "format": "biome format --write ./src",


### PR DESCRIPTION
## Summary
- Adds `prisma generate` to the `build` script so the Prisma client is always generated before `next build`
- Adds `postinstall` script to auto-generate the client after `pnpm install` (also used by Vercel deployments)

## Test plan
- [ ] Run `pnpm build` on a clean checkout (no `src/generated/prisma/`) — should succeed
- [ ] Deploy to Vercel preview — build should pass without manual `prisma generate`