### PR TITLE
feat(cv): structured JSON tailor schema with markdown serializer

### DIFF
--- a/prisma/migrations/20260427004712_add_tailored_cv_json/migration.sql
+++ b/prisma/migrations/20260427004712_add_tailored_cv_json/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "JobApplication" ADD COLUMN     "tailoredCvJson" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,7 @@ model JobApplication {
   matchAnalysis      Json?
   tailoredCV         String?           @db.Text
   tailoredCVEdited   String?           @db.Text
+  tailoredCvJson     Json?
   coverLetter        String?           @db.Text
   status             ApplicationStatus @default(DRAFT)
   notes              String?           @db.Text

--- a/src/app/api/applications/[id]/route.test.ts
+++ b/src/app/api/applications/[id]/route.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolveEditedTailoredCvJson } from "./route";
+
+describe("resolveEditedTailoredCvJson", () => {
+	it("leaves JSON untouched when tailoredCVEdited is absent from the patch", () => {
+		expect(resolveEditedTailoredCvJson(undefined)).toEqual({ kind: "leave" });
+	});
+
+	it("clears JSON when the editor is cleared to empty string", () => {
+		expect(resolveEditedTailoredCvJson("")).toEqual({ kind: "clear" });
+		expect(resolveEditedTailoredCvJson("   \n  ")).toEqual({ kind: "clear" });
+	});
+
+	it("clears JSON when edited content is HTML (Tiptap) so it is not silently stale", () => {
+		const html = "<p>Edited CV from the rich-text editor.</p>";
+		expect(resolveEditedTailoredCvJson(html)).toEqual({ kind: "clear" });
+	});
+
+	it("sets JSON to the parsed structure when edited content is markdown", () => {
+		const md = "# Jane Doe\n\njane@example.com\n\n## Summary\n\nTen years of experience.";
+		const result = resolveEditedTailoredCvJson(md);
+		expect(result.kind).toBe("set");
+		if (result.kind !== "set") return;
+		const value = result.value as { header: { name: string }; summary: string };
+		expect(value.header.name).toBe("Jane Doe");
+		expect(value.summary).toContain("Ten years");
+	});
+});

--- a/src/app/api/applications/[id]/route.ts
+++ b/src/app/api/applications/[id]/route.ts
@@ -1,6 +1,8 @@
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
+import type { Prisma } from "@/generated/prisma/client";
 import { auth } from "@/lib/auth";
+import { markdownToJson } from "@/lib/cv-serializer";
 import { prisma } from "@/lib/prisma";
 import { updateApplicationSchema } from "@/lib/validations";
 
@@ -8,6 +10,19 @@ async function getApplication(userId: string, id: string) {
 	return prisma.jobApplication.findFirst({
 		where: { id, userId },
 	});
+}
+
+async function backfillTailoredCvJson(id: string, markdown: string) {
+	try {
+		const parsed = markdownToJson(markdown);
+		await prisma.jobApplication.update({
+			where: { id },
+			data: { tailoredCvJson: parsed },
+		});
+		return parsed;
+	} catch {
+		return null;
+	}
 }
 
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -20,6 +35,14 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
 	const application = await getApplication(session.user.id, id);
 	if (!application) {
 		return NextResponse.json({ error: "Not found" }, { status: 404 });
+	}
+
+	const markdown = application.tailoredCVEdited ?? application.tailoredCV;
+	if (!application.tailoredCvJson && markdown) {
+		const backfilled = await backfillTailoredCvJson(application.id, markdown);
+		if (backfilled) {
+			return NextResponse.json({ ...application, tailoredCvJson: backfilled });
+		}
 	}
 
 	return NextResponse.json(application);
@@ -46,9 +69,20 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 		);
 	}
 
+	const data: Prisma.JobApplicationUpdateInput = { ...parsed.data };
+	if (parsed.data.tailoredCVEdited) {
+		try {
+			data.tailoredCvJson = markdownToJson(
+				parsed.data.tailoredCVEdited,
+			) as unknown as Prisma.InputJsonValue;
+		} catch {
+			// keep markdown edit, leave JSON unchanged
+		}
+	}
+
 	const updated = await prisma.jobApplication.update({
 		where: { id },
-		data: parsed.data,
+		data,
 	});
 
 	return NextResponse.json(updated);

--- a/src/app/api/applications/[id]/route.ts
+++ b/src/app/api/applications/[id]/route.ts
@@ -1,6 +1,6 @@
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
-import type { Prisma } from "@/generated/prisma/client";
+import { Prisma } from "@/generated/prisma/client";
 import { auth } from "@/lib/auth";
 import { markdownToJson } from "@/lib/cv-serializer";
 import { prisma } from "@/lib/prisma";
@@ -10,6 +10,30 @@ async function getApplication(userId: string, id: string) {
 	return prisma.jobApplication.findFirst({
 		where: { id, userId },
 	});
+}
+
+/**
+ * Decide what to write to tailoredCvJson when tailoredCVEdited changes.
+ * - undefined → field not in PATCH body, leave Prisma update untouched.
+ * - "" or whitespace → user cleared the editor, clear JSON too.
+ * - parses cleanly → use parsed JSON.
+ * - throws (e.g. HTML from Tiptap, see #15) → clear JSON so it's not stale
+ *   vs. the new edited markdown. Re-tailor will repopulate.
+ */
+export function resolveEditedTailoredCvJson(
+	edited: string | undefined,
+):
+	| { kind: "leave" }
+	| { kind: "clear" }
+	| { kind: "set"; value: Prisma.InputJsonValue } {
+	if (edited === undefined) return { kind: "leave" };
+	if (!edited.trim()) return { kind: "clear" };
+	try {
+		const parsed = markdownToJson(edited) as unknown as Prisma.InputJsonValue;
+		return { kind: "set", value: parsed };
+	} catch {
+		return { kind: "clear" };
+	}
 }
 
 async function backfillTailoredCvJson(id: string, markdown: string) {
@@ -70,15 +94,9 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 	}
 
 	const data: Prisma.JobApplicationUpdateInput = { ...parsed.data };
-	if (parsed.data.tailoredCVEdited) {
-		try {
-			data.tailoredCvJson = markdownToJson(
-				parsed.data.tailoredCVEdited,
-			) as unknown as Prisma.InputJsonValue;
-		} catch {
-			// keep markdown edit, leave JSON unchanged
-		}
-	}
+	const decision = resolveEditedTailoredCvJson(parsed.data.tailoredCVEdited);
+	if (decision.kind === "set") data.tailoredCvJson = decision.value;
+	else if (decision.kind === "clear") data.tailoredCvJson = Prisma.JsonNull;
 
 	const updated = await prisma.jobApplication.update({
 		where: { id },

--- a/src/app/api/applications/[id]/tailor/route.ts
+++ b/src/app/api/applications/[id]/tailor/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import type { MatchAnalysis } from "@/lib/gemini";
 import { tailorCV } from "@/lib/gemini";
 import { auth } from "@/lib/auth";
+import { jsonToMarkdown } from "@/lib/cv-serializer";
 import { prisma } from "@/lib/prisma";
 
 export async function POST(
@@ -40,17 +41,19 @@ export async function POST(
 	}
 
 	try {
-		const tailored = await tailorCV(
+		const tailoredJson = await tailorCV(
 			masterCV.rawText,
 			application.rawDescription,
 			application.matchAnalysis as unknown as MatchAnalysis,
 		);
+		const tailoredMarkdown = jsonToMarkdown(tailoredJson);
 
 		const updated = await prisma.jobApplication.update({
 			where: { id },
 			data: {
-				tailoredCV: tailored,
-				tailoredCVEdited: tailored,
+				tailoredCV: tailoredMarkdown,
+				tailoredCVEdited: tailoredMarkdown,
+				tailoredCvJson: tailoredJson,
 				status: "TAILORED",
 			},
 		});

--- a/src/lib/cv-schema.ts
+++ b/src/lib/cv-schema.ts
@@ -1,0 +1,166 @@
+import { z } from "zod";
+
+const HeaderLinkSchema = z.object({
+	url: z.string(),
+	label: z.string().optional(),
+});
+
+const HeaderSchema = z.object({
+	name: z.string(),
+	title: z.string().optional(),
+	email: z.string().optional(),
+	phone: z.string().optional(),
+	location: z.string().optional(),
+	links: z.array(HeaderLinkSchema).default([]),
+});
+
+const SkillGroupSchema = z.object({
+	category: z.string(),
+	items: z.array(z.string()).default([]),
+});
+
+const ExperienceSchema = z.object({
+	company: z.string(),
+	role: z.string(),
+	location: z.string().optional(),
+	start: z.string().optional(),
+	end: z.string().optional(),
+	bullets: z.array(z.string()).default([]),
+});
+
+const EducationSchema = z.object({
+	school: z.string(),
+	degree: z.string().optional(),
+	start: z.string().optional(),
+	end: z.string().optional(),
+	details: z.string().optional(),
+});
+
+const ProjectSchema = z.object({
+	name: z.string(),
+	url: z.string().optional(),
+	description: z.string().optional(),
+	bullets: z.array(z.string()).default([]),
+});
+
+const CertificationSchema = z.object({
+	name: z.string(),
+	issuer: z.string().optional(),
+	date: z.string().optional(),
+});
+
+export const TailoredCvSchema = z.object({
+	header: HeaderSchema,
+	summary: z.string().default(""),
+	skills: z.array(SkillGroupSchema).default([]),
+	experience: z.array(ExperienceSchema).default([]),
+	education: z.array(EducationSchema).default([]),
+	projects: z.array(ProjectSchema).default([]),
+	certifications: z.array(CertificationSchema).default([]),
+});
+
+export type TailoredCv = z.infer<typeof TailoredCvSchema>;
+export type TailoredCvHeader = z.infer<typeof HeaderSchema>;
+export type TailoredCvExperience = z.infer<typeof ExperienceSchema>;
+export type TailoredCvSkillGroup = z.infer<typeof SkillGroupSchema>;
+export type TailoredCvEducation = z.infer<typeof EducationSchema>;
+export type TailoredCvProject = z.infer<typeof ProjectSchema>;
+export type TailoredCvCertification = z.infer<typeof CertificationSchema>;
+
+// JSON schema mirror of TailoredCvSchema for Gemini structured output.
+// Hand-maintained to avoid a runtime zod-to-json-schema dependency; keep in
+// sync with TailoredCvSchema above.
+export const TailoredCvResponseSchema = {
+	type: "object",
+	properties: {
+		header: {
+			type: "object",
+			properties: {
+				name: { type: "string" },
+				title: { type: "string" },
+				email: { type: "string" },
+				phone: { type: "string" },
+				location: { type: "string" },
+				links: {
+					type: "array",
+					items: {
+						type: "object",
+						properties: {
+							url: { type: "string" },
+							label: { type: "string" },
+						},
+						required: ["url"],
+					},
+				},
+			},
+			required: ["name"],
+		},
+		summary: { type: "string" },
+		skills: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					category: { type: "string" },
+					items: { type: "array", items: { type: "string" } },
+				},
+				required: ["category", "items"],
+			},
+		},
+		experience: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					company: { type: "string" },
+					role: { type: "string" },
+					location: { type: "string" },
+					start: { type: "string" },
+					end: { type: "string" },
+					bullets: { type: "array", items: { type: "string" } },
+				},
+				required: ["company", "role"],
+			},
+		},
+		education: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					school: { type: "string" },
+					degree: { type: "string" },
+					start: { type: "string" },
+					end: { type: "string" },
+					details: { type: "string" },
+				},
+				required: ["school"],
+			},
+		},
+		projects: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					name: { type: "string" },
+					url: { type: "string" },
+					description: { type: "string" },
+					bullets: { type: "array", items: { type: "string" } },
+				},
+				required: ["name"],
+			},
+		},
+		certifications: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					name: { type: "string" },
+					issuer: { type: "string" },
+					date: { type: "string" },
+				},
+				required: ["name"],
+			},
+		},
+	},
+	required: ["header", "summary"],
+} as const;

--- a/src/lib/cv-serializer.test.ts
+++ b/src/lib/cv-serializer.test.ts
@@ -104,6 +104,8 @@ describe("cv-serializer", () => {
 
 		expect(parsed.education[0].school).toBe("State University");
 		expect(parsed.education[0].degree).toBe("B.S. Computer Science");
+		expect(parsed.education[0].start).toBe("2013");
+		expect(parsed.education[0].end).toBe("2017");
 
 		expect(parsed.projects[0].name).toBe("OpenLogger");
 		expect(parsed.projects[0].url).toBe("https://github.com/jane/openlogger");
@@ -118,6 +120,22 @@ describe("cv-serializer", () => {
 			"<p>Here is your CV.</p><h1>Jane Doe</h1><p>jane@example.com</p>";
 		expect(looksLikeHtml(html)).toBe(true);
 		expect(() => markdownToJson(html)).toThrow(/HTML/);
+	});
+
+	it("detects a broad set of HTML inputs (not just p/div/h1)", () => {
+		expect(looksLikeHtml("<table><tr><td>x</td></tr></table>")).toBe(true);
+		expect(looksLikeHtml("<article>Body</article>")).toBe(true);
+		expect(looksLikeHtml("<section>x</section>")).toBe(true);
+		expect(looksLikeHtml("<!DOCTYPE html><html><body>x</body></html>")).toBe(true);
+		expect(looksLikeHtml("<!-- comment --><p>after</p>")).toBe(true);
+		expect(looksLikeHtml('<?xml version="1.0"?><root/>')).toBe(true);
+		expect(looksLikeHtml("<custom-element>x</custom-element>")).toBe(true);
+		expect(looksLikeHtml("</closing>")).toBe(true);
+
+		// Negative cases — these are real markdown leading characters.
+		expect(looksLikeHtml("# Heading\n\nBody")).toBe(false);
+		expect(looksLikeHtml("- bullet")).toBe(false);
+		expect(looksLikeHtml("Just plain text")).toBe(false);
 	});
 
 	it("handles markdown with missing optional sections", () => {

--- a/src/lib/cv-serializer.test.ts
+++ b/src/lib/cv-serializer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TailoredCv } from "@/lib/cv-schema";
-import { jsonToMarkdown, markdownToJson } from "@/lib/cv-serializer";
+import { jsonToMarkdown, looksLikeHtml, markdownToJson } from "@/lib/cv-serializer";
 
 const sample: TailoredCv = {
 	header: {
@@ -111,6 +111,13 @@ describe("cv-serializer", () => {
 		expect(parsed.certifications[0].name).toBe("AWS Solutions Architect");
 		expect(parsed.certifications[0].issuer).toBe("AWS");
 		expect(parsed.certifications[0].date).toBe("2023");
+	});
+
+	it("refuses to parse HTML (Tiptap output) as markdown", () => {
+		const html =
+			"<p>Here is your CV.</p><h1>Jane Doe</h1><p>jane@example.com</p>";
+		expect(looksLikeHtml(html)).toBe(true);
+		expect(() => markdownToJson(html)).toThrow(/HTML/);
 	});
 
 	it("handles markdown with missing optional sections", () => {

--- a/src/lib/cv-serializer.test.ts
+++ b/src/lib/cv-serializer.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type { TailoredCv } from "@/lib/cv-schema";
+import { jsonToMarkdown, markdownToJson } from "@/lib/cv-serializer";
+
+const sample: TailoredCv = {
+	header: {
+		name: "Jane Doe",
+		title: "Senior Software Engineer",
+		email: "jane@example.com",
+		phone: "+1 555 123 4567",
+		location: "Remote",
+		links: [
+			{ url: "https://github.com/janedoe", label: "GitHub" },
+			{ url: "https://janedoe.dev" },
+		],
+	},
+	summary: "Engineer with 8 years of experience building scalable web platforms.",
+	skills: [
+		{ category: "Languages", items: ["TypeScript", "Python", "Go"] },
+		{ category: "Frameworks", items: ["Next.js", "React", "FastAPI"] },
+	],
+	experience: [
+		{
+			company: "Acme Corp",
+			role: "Staff Engineer",
+			location: "Remote",
+			start: "2022",
+			end: "Present",
+			bullets: [
+				"Led migration to **Next.js** App Router across 12 services.",
+				"Cut p95 latency 35% by introducing edge caching.",
+			],
+		},
+		{
+			company: "Globex",
+			role: "Senior Engineer",
+			start: "2019",
+			end: "2022",
+			bullets: ["Shipped real-time billing pipeline handling 2M events/day."],
+		},
+	],
+	education: [
+		{
+			school: "State University",
+			degree: "B.S. Computer Science",
+			start: "2013",
+			end: "2017",
+		},
+	],
+	projects: [
+		{
+			name: "OpenLogger",
+			url: "https://github.com/jane/openlogger",
+			description: "Structured logging library for Deno.",
+			bullets: ["1.2k GitHub stars", "Used in production by three startups"],
+		},
+	],
+	certifications: [
+		{ name: "AWS Solutions Architect", issuer: "AWS", date: "2023" },
+	],
+};
+
+describe("cv-serializer", () => {
+	it("renders JSON to markdown with sections and bullets", () => {
+		const md = jsonToMarkdown(sample);
+		expect(md).toContain("# Jane Doe");
+		expect(md).toContain("**Senior Software Engineer**");
+		expect(md).toContain("## Summary");
+		expect(md).toContain("## Skills");
+		expect(md).toContain("- **Languages:** TypeScript, Python, Go");
+		expect(md).toContain("## Experience");
+		expect(md).toContain("### Acme Corp — *Staff Engineer*");
+		expect(md).toContain("Led migration to **Next.js**");
+		expect(md).toContain("## Education");
+		expect(md).toContain("## Projects");
+		expect(md).toContain("## Certifications");
+	});
+
+	it("round-trips core fields through markdown→JSON parser", () => {
+		const md = jsonToMarkdown(sample);
+		const parsed = markdownToJson(md);
+
+		expect(parsed.header.name).toBe("Jane Doe");
+		expect(parsed.header.title).toBe("Senior Software Engineer");
+		expect(parsed.header.email).toBe("jane@example.com");
+		expect(parsed.header.phone).toBe("+1 555 123 4567");
+		expect(parsed.header.links.map((l) => l.url)).toContain("https://janedoe.dev");
+		expect(parsed.header.links.find((l) => l.label === "GitHub")?.url).toBe(
+			"https://github.com/janedoe",
+		);
+
+		expect(parsed.summary).toContain("8 years");
+
+		expect(parsed.skills).toHaveLength(2);
+		expect(parsed.skills[0].category).toBe("Languages");
+		expect(parsed.skills[0].items).toEqual(["TypeScript", "Python", "Go"]);
+
+		expect(parsed.experience).toHaveLength(2);
+		expect(parsed.experience[0].company).toBe("Acme Corp");
+		expect(parsed.experience[0].role).toBe("Staff Engineer");
+		expect(parsed.experience[0].start).toBe("2022");
+		expect(parsed.experience[0].end).toBe("Present");
+		expect(parsed.experience[0].bullets[0]).toContain("Next.js");
+
+		expect(parsed.education[0].school).toBe("State University");
+		expect(parsed.education[0].degree).toBe("B.S. Computer Science");
+
+		expect(parsed.projects[0].name).toBe("OpenLogger");
+		expect(parsed.projects[0].url).toBe("https://github.com/jane/openlogger");
+
+		expect(parsed.certifications[0].name).toBe("AWS Solutions Architect");
+		expect(parsed.certifications[0].issuer).toBe("AWS");
+		expect(parsed.certifications[0].date).toBe("2023");
+	});
+
+	it("handles markdown with missing optional sections", () => {
+		const minimal = "# John Smith\n\njohn@example.com\n\n## Summary\n\nMinimal CV.";
+		const parsed = markdownToJson(minimal);
+		expect(parsed.header.name).toBe("John Smith");
+		expect(parsed.header.email).toBe("john@example.com");
+		expect(parsed.summary).toBe("Minimal CV.");
+		expect(parsed.experience).toEqual([]);
+		expect(parsed.education).toEqual([]);
+	});
+});

--- a/src/lib/cv-serializer.ts
+++ b/src/lib/cv-serializer.ts
@@ -1,0 +1,386 @@
+import type { TailoredCv } from "@/lib/cv-schema";
+import { TailoredCvSchema } from "@/lib/cv-schema";
+
+const SECTION_HEADINGS = {
+	summary: "Summary",
+	skills: "Skills",
+	experience: "Experience",
+	education: "Education",
+	projects: "Projects",
+	certifications: "Certifications",
+} as const;
+
+// ─── JSON → Markdown ────────────────────────────────────────────────────
+
+export function jsonToMarkdown(cv: TailoredCv): string {
+	const lines: string[] = [];
+
+	lines.push(`# ${cv.header.name}`);
+	if (cv.header.title) lines.push(`**${cv.header.title}**`);
+
+	const contactBits: string[] = [];
+	if (cv.header.email) contactBits.push(cv.header.email);
+	if (cv.header.phone) contactBits.push(cv.header.phone);
+	if (cv.header.location) contactBits.push(cv.header.location);
+	for (const link of cv.header.links) {
+		contactBits.push(link.label ? `[${link.label}](${link.url})` : link.url);
+	}
+	if (contactBits.length > 0) lines.push(contactBits.join(" • "));
+
+	if (cv.summary?.trim()) {
+		lines.push("", `## ${SECTION_HEADINGS.summary}`, "", cv.summary.trim());
+	}
+
+	if (cv.skills.length > 0) {
+		lines.push("", `## ${SECTION_HEADINGS.skills}`, "");
+		for (const group of cv.skills) {
+			lines.push(`- **${group.category}:** ${group.items.join(", ")}`);
+		}
+	}
+
+	if (cv.experience.length > 0) {
+		lines.push("", `## ${SECTION_HEADINGS.experience}`, "");
+		for (const job of cv.experience) {
+			const dates = formatDateRange(job.start, job.end);
+			const headerRight = [job.location, dates].filter(Boolean).join(" | ");
+			lines.push(`### ${job.company} — *${job.role}*`);
+			if (headerRight) lines.push(`*${headerRight}*`);
+			lines.push("");
+			for (const bullet of job.bullets) lines.push(`- ${bullet}`);
+			lines.push("");
+		}
+	}
+
+	if (cv.education.length > 0) {
+		lines.push(`## ${SECTION_HEADINGS.education}`, "");
+		for (const edu of cv.education) {
+			const dates = formatDateRange(edu.start, edu.end);
+			const right = dates ? ` *(${dates})*` : "";
+			const degree = edu.degree ? ` — ${edu.degree}` : "";
+			lines.push(`### ${edu.school}${degree}${right}`);
+			if (edu.details) lines.push(edu.details);
+			lines.push("");
+		}
+	}
+
+	if (cv.projects.length > 0) {
+		lines.push(`## ${SECTION_HEADINGS.projects}`, "");
+		for (const project of cv.projects) {
+			const linkPart = project.url ? ` ([link](${project.url}))` : "";
+			lines.push(`### ${project.name}${linkPart}`);
+			if (project.description) lines.push(project.description);
+			for (const bullet of project.bullets) lines.push(`- ${bullet}`);
+			lines.push("");
+		}
+	}
+
+	if (cv.certifications.length > 0) {
+		lines.push(`## ${SECTION_HEADINGS.certifications}`, "");
+		for (const cert of cv.certifications) {
+			const meta = [cert.issuer, cert.date].filter(Boolean).join(" • ");
+			lines.push(`- **${cert.name}**${meta ? ` — ${meta}` : ""}`);
+		}
+	}
+
+	return lines.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function formatDateRange(start?: string, end?: string): string {
+	if (start && end) return `${start} – ${end}`;
+	if (start) return start;
+	if (end) return end;
+	return "";
+}
+
+// ─── Markdown → JSON (best-effort) ──────────────────────────────────────
+
+interface RawSection {
+	heading: string;
+	lines: string[];
+}
+
+export function markdownToJson(markdown: string): TailoredCv {
+	const sections = splitIntoSections(markdown);
+	const cv: TailoredCv = TailoredCvSchema.parse({
+		header: parseHeader(sections.preamble),
+		summary: extractSummary(sections.byKey.summary),
+		skills: parseSkills(sections.byKey.skills),
+		experience: parseExperience(sections.byKey.experience),
+		education: parseEducation(sections.byKey.education),
+		projects: parseProjects(sections.byKey.projects),
+		certifications: parseCertifications(sections.byKey.certifications),
+	});
+	return cv;
+}
+
+function splitIntoSections(markdown: string): {
+	preamble: string[];
+	byKey: Record<string, RawSection | undefined>;
+} {
+	const lines = markdown.split("\n");
+	const preamble: string[] = [];
+	const byKey: Record<string, RawSection> = {};
+	let current: RawSection | null = null;
+
+	for (const line of lines) {
+		const h2 = line.match(/^##\s+(.+?)\s*$/);
+		if (h2 && !line.startsWith("###")) {
+			const heading = h2[1].trim();
+			current = { heading, lines: [] };
+			byKey[normalizeKey(heading)] = current;
+			continue;
+		}
+		if (current) {
+			current.lines.push(line);
+		} else {
+			preamble.push(line);
+		}
+	}
+	return { preamble, byKey };
+}
+
+function normalizeKey(heading: string): string {
+	const lower = heading.toLowerCase();
+	if (lower.includes("summary") || lower.includes("objective") || lower.includes("profile"))
+		return "summary";
+	if (lower.includes("skill")) return "skills";
+	if (lower.includes("experience") || lower.includes("employment") || lower.includes("work"))
+		return "experience";
+	if (lower.includes("education")) return "education";
+	if (lower.includes("project")) return "projects";
+	if (lower.includes("certif") || lower.includes("license")) return "certifications";
+	return lower;
+}
+
+function parseHeader(preamble: string[]): TailoredCv["header"] {
+	const trimmed = preamble.map((l) => l.trim()).filter(Boolean);
+	const nameLine = trimmed.find((l) => l.startsWith("# ")) ?? trimmed[0] ?? "";
+	const name = nameLine.replace(/^#\s+/, "").replace(/\*\*/g, "").trim() || "Unknown";
+
+	const remaining = trimmed.filter((l) => l !== nameLine);
+	let title: string | undefined;
+	const contactCandidates: string[] = [];
+	for (const line of remaining) {
+		if (/^\*\*.+\*\*$/.test(line) && !title) {
+			title = line.replace(/^\*\*|\*\*$/g, "").trim();
+			continue;
+		}
+		contactCandidates.push(line);
+	}
+
+	const links: { url: string; label?: string }[] = [];
+	let email: string | undefined;
+	let phone: string | undefined;
+	let location: string | undefined;
+
+	for (const candidate of contactCandidates) {
+		const tokens = candidate.split(/\s*[•|]\s*/);
+		for (const token of tokens) {
+			if (!token.trim()) continue;
+			const linkMatch = token.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+			if (linkMatch) {
+				links.push({ label: linkMatch[1], url: linkMatch[2] });
+				continue;
+			}
+			if (/^https?:\/\//.test(token)) {
+				links.push({ url: token });
+				continue;
+			}
+			if (token.includes("@") && !email) {
+				email = token;
+				continue;
+			}
+			if (/[\d()+-][\d\s()+-]{6,}/.test(token) && !phone) {
+				phone = token;
+				continue;
+			}
+			if (!location) location = token;
+		}
+	}
+
+	return { name, title, email, phone, location, links };
+}
+
+function extractSummary(section: RawSection | undefined): string {
+	if (!section) return "";
+	return section.lines
+		.map((l) => l.trim())
+		.filter(Boolean)
+		.join(" ")
+		.trim();
+}
+
+function parseSkills(section: RawSection | undefined): TailoredCv["skills"] {
+	if (!section) return [];
+	const groups: TailoredCv["skills"] = [];
+	for (const raw of section.lines) {
+		const line = raw.trim();
+		if (!line.startsWith("- ") && !line.startsWith("* ")) continue;
+		const stripped = line.slice(2);
+		const colonIdx = stripped.indexOf(":");
+		if (colonIdx === -1) {
+			groups.push({ category: "General", items: splitItems(stripped) });
+			continue;
+		}
+		const category = stripped.slice(0, colonIdx).replace(/\*\*/g, "").trim();
+		const items = splitItems(stripped.slice(colonIdx + 1));
+		groups.push({ category, items });
+	}
+	return groups;
+}
+
+function splitItems(text: string): string[] {
+	return text
+		.split(/[,;]/)
+		.map((s) => s.trim().replace(/^\*\*|\*\*$/g, "").trim())
+		.filter(Boolean);
+}
+
+function parseExperience(section: RawSection | undefined): TailoredCv["experience"] {
+	if (!section) return [];
+	return parseEntries(section.lines).map((entry) => {
+		const { company, role } = splitCompanyRole(entry.heading);
+		const { location, start, end } = parseMetaLine(entry.metaLine);
+		return {
+			company,
+			role,
+			location,
+			start,
+			end,
+			bullets: entry.bullets,
+		};
+	});
+}
+
+function parseEducation(section: RawSection | undefined): TailoredCv["education"] {
+	if (!section) return [];
+	return parseEntries(section.lines).map((entry) => {
+		const { primary, secondary } = splitOnDash(entry.heading);
+		const { start, end } = parseMetaLine(entry.metaLine);
+		return {
+			school: primary,
+			degree: secondary,
+			start,
+			end,
+			details: entry.bullets.join(" ") || undefined,
+		};
+	});
+}
+
+function parseProjects(section: RawSection | undefined): TailoredCv["projects"] {
+	if (!section) return [];
+	return parseEntries(section.lines).map((entry) => {
+		const linkMatch = entry.heading.match(/\(\[(?:link|url)\]\(([^)]+)\)\)\s*$/i);
+		const url = linkMatch?.[1];
+		const name = entry.heading.replace(/\s*\(\[[^\]]+\]\([^)]+\)\)\s*$/, "").trim();
+		return {
+			name,
+			url,
+			description: entry.metaLine || undefined,
+			bullets: entry.bullets,
+		};
+	});
+}
+
+function parseCertifications(
+	section: RawSection | undefined,
+): TailoredCv["certifications"] {
+	if (!section) return [];
+	const certs: TailoredCv["certifications"] = [];
+	for (const raw of section.lines) {
+		const line = raw.trim();
+		if (!line.startsWith("- ") && !line.startsWith("* ")) continue;
+		const stripped = line.slice(2).replace(/\*\*/g, "");
+		const dashIdx = stripped.indexOf(" — ");
+		if (dashIdx === -1) {
+			certs.push({ name: stripped.trim() });
+			continue;
+		}
+		const name = stripped.slice(0, dashIdx).trim();
+		const metaParts = stripped
+			.slice(dashIdx + 3)
+			.split(/\s*•\s*/)
+			.map((s) => s.trim())
+			.filter(Boolean);
+		certs.push({
+			name,
+			issuer: metaParts[0],
+			date: metaParts[1],
+		});
+	}
+	return certs;
+}
+
+interface ParsedEntry {
+	heading: string;
+	metaLine: string;
+	bullets: string[];
+}
+
+function parseEntries(lines: string[]): ParsedEntry[] {
+	const entries: ParsedEntry[] = [];
+	let current: ParsedEntry | null = null;
+	for (const raw of lines) {
+		const line = raw.trim();
+		if (!line) continue;
+		const h3 = line.match(/^###\s+(.+)/);
+		if (h3) {
+			if (current) entries.push(current);
+			current = { heading: h3[1].trim(), metaLine: "", bullets: [] };
+			continue;
+		}
+		if (!current) continue;
+		if (line.startsWith("- ") || line.startsWith("* ")) {
+			current.bullets.push(line.slice(2).trim());
+			continue;
+		}
+		if (!current.metaLine) current.metaLine = line.replace(/^\*|\*$/g, "").trim();
+	}
+	if (current) entries.push(current);
+	return entries;
+}
+
+function splitCompanyRole(heading: string): { company: string; role: string } {
+	const cleaned = heading.replace(/\*/g, "");
+	const dashMatch = cleaned.match(/^(.+?)\s+[—–-]\s+(.+)$/);
+	if (dashMatch) {
+		return { company: dashMatch[1].trim(), role: dashMatch[2].trim() };
+	}
+	return { company: cleaned.trim(), role: "" };
+}
+
+function splitOnDash(heading: string): { primary: string; secondary?: string } {
+	const cleaned = heading.replace(/\s*\*\([^)]+\)\*\s*$/, "").replace(/\*/g, "");
+	const dashMatch = cleaned.match(/^(.+?)\s+[—–-]\s+(.+)$/);
+	if (dashMatch) {
+		return { primary: dashMatch[1].trim(), secondary: dashMatch[2].trim() };
+	}
+	return { primary: cleaned.trim() };
+}
+
+function parseMetaLine(meta: string): {
+	location?: string;
+	start?: string;
+	end?: string;
+} {
+	if (!meta) return {};
+	const cleaned = meta.replace(/\*/g, "").trim();
+	const parts = cleaned.split(/\s*\|\s*/);
+	let location: string | undefined;
+	let dateRange: string | undefined;
+	for (const part of parts) {
+		if (/\d{4}/.test(part) || /present/i.test(part)) {
+			dateRange = part;
+		} else if (!location) {
+			location = part;
+		}
+	}
+	if (!dateRange && (/\d{4}/.test(cleaned) || /present/i.test(cleaned))) {
+		dateRange = cleaned;
+	}
+	const range = dateRange?.match(/^(.+?)\s*[–-]\s*(.+)$/);
+	if (range) {
+		return { location, start: range[1].trim(), end: range[2].trim() };
+	}
+	return { location, start: dateRange };
+}

--- a/src/lib/cv-serializer.ts
+++ b/src/lib/cv-serializer.ts
@@ -52,7 +52,7 @@ export function jsonToMarkdown(cv: TailoredCv): string {
 	}
 
 	if (cv.education.length > 0) {
-		lines.push(`## ${SECTION_HEADINGS.education}`, "");
+		lines.push("", `## ${SECTION_HEADINGS.education}`, "");
 		for (const edu of cv.education) {
 			const dates = formatDateRange(edu.start, edu.end);
 			const right = dates ? ` *(${dates})*` : "";
@@ -64,7 +64,7 @@ export function jsonToMarkdown(cv: TailoredCv): string {
 	}
 
 	if (cv.projects.length > 0) {
-		lines.push(`## ${SECTION_HEADINGS.projects}`, "");
+		lines.push("", `## ${SECTION_HEADINGS.projects}`, "");
 		for (const project of cv.projects) {
 			const linkPart = project.url ? ` ([link](${project.url}))` : "";
 			lines.push(`### ${project.name}${linkPart}`);
@@ -75,7 +75,7 @@ export function jsonToMarkdown(cv: TailoredCv): string {
 	}
 
 	if (cv.certifications.length > 0) {
-		lines.push(`## ${SECTION_HEADINGS.certifications}`, "");
+		lines.push("", `## ${SECTION_HEADINGS.certifications}`, "");
 		for (const cert of cv.certifications) {
 			const meta = [cert.issuer, cert.date].filter(Boolean).join(" • ");
 			lines.push(`- **${cert.name}**${meta ? ` — ${meta}` : ""}`);
@@ -108,7 +108,9 @@ interface RawSection {
  */
 export function looksLikeHtml(input: string): boolean {
 	const trimmed = input.trimStart();
-	return /^<(?:p|h[1-6]|ul|ol|div|span|strong|em|br)\b/i.test(trimmed);
+	// Match: opening/closing tags, HTML comments, doctype, XML processing instructions.
+	// Tag name pattern allows hyphens (custom elements) and namespace colons.
+	return /^<\s*(?:!--|!doctype\b|\?xml\b|\/?[a-z][\w:-]*)/i.test(trimmed);
 }
 
 export function markdownToJson(markdown: string): TailoredCv {
@@ -270,13 +272,15 @@ function parseExperience(section: RawSection | undefined): TailoredCv["experienc
 function parseEducation(section: RawSection | undefined): TailoredCv["education"] {
 	if (!section) return [];
 	return parseEntries(section.lines).map((entry) => {
+		const trailingDate = entry.heading.match(/\*\(([^)]+)\)\*\s*$/)?.[1];
 		const { primary, secondary } = splitOnDash(entry.heading);
-		const { start, end } = parseMetaLine(entry.metaLine);
+		const fromMeta = parseMetaLine(entry.metaLine);
+		const fromHeading = trailingDate ? parseMetaLine(trailingDate) : {};
 		return {
 			school: primary,
 			degree: secondary,
-			start,
-			end,
+			start: fromMeta.start ?? fromHeading.start,
+			end: fromMeta.end ?? fromHeading.end,
 			details: entry.bullets.join(" ") || undefined,
 		};
 	});

--- a/src/lib/cv-serializer.ts
+++ b/src/lib/cv-serializer.ts
@@ -99,7 +99,22 @@ interface RawSection {
 	lines: string[];
 }
 
+/**
+ * Tiptap stores edited content as HTML. Best-effort markdown parsing on HTML
+ * input dumps the entire blob into header.name and yields zero sections, so
+ * we refuse rather than persist garbage. Callers should treat this as
+ * "JSON not available" and leave the legacy markdown/HTML column as the source
+ * of truth until the next re-tailor populates structured JSON cleanly.
+ */
+export function looksLikeHtml(input: string): boolean {
+	const trimmed = input.trimStart();
+	return /^<(?:p|h[1-6]|ul|ol|div|span|strong|em|br)\b/i.test(trimmed);
+}
+
 export function markdownToJson(markdown: string): TailoredCv {
+	if (looksLikeHtml(markdown)) {
+		throw new Error("Input is HTML, not markdown — refusing to parse");
+	}
 	const sections = splitIntoSections(markdown);
 	const cv: TailoredCv = TailoredCvSchema.parse({
 		header: parseHeader(sections.preamble),

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,4 +1,6 @@
 import { GoogleGenAI } from "@google/genai";
+import type { TailoredCv } from "@/lib/cv-schema";
+import { TailoredCvResponseSchema, TailoredCvSchema } from "@/lib/cv-schema";
 
 const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY! });
 const MODEL = "gemini-3.1-pro-preview";
@@ -236,7 +238,7 @@ export async function tailorCV(
 	cvText: string,
 	jobDescription: string,
 	matchAnalysis: MatchAnalysis,
-): Promise<string> {
+): Promise<TailoredCv> {
 	return withRetry(async () => {
 		const response = await ai.models.generateContent({
 			model: MODEL,
@@ -248,15 +250,17 @@ export async function tailorCV(
 							text: `You are an expert CV writer and ATS optimization specialist. Tailor this CV for the specific job description.
 
 CRITICAL RULES:
-- NEVER fabricate experience, skills, or qualifications
-- Reorder sections to prioritize the most relevant experience
-- Mirror exact keywords from the job description where truthful
-- Add quantifiable metrics where possible (from existing experience)
-- Compress or remove less relevant experience
-- Strengthen bullet points to align with job requirements
-- Maintain professional, concise language
+- NEVER fabricate experience, skills, or qualifications. Only include items that appear verbatim or as a clear synonym in ORIGINAL CV.
+- Reorder sections to prioritize the most relevant experience.
+- Mirror exact keywords from the job description where truthful.
+- Preserve quantifiable metrics from the original; do not invent new numbers.
+- Compress or remove less relevant experience.
+- Strengthen bullet points to align with job requirements.
+- Use \`**term**\` (markdown bold) inside bullet text to flag JD keywords that should render emphasized in the final document.
+- Keep links in header.links as { url, label }.
 
-Output the tailored CV as clean markdown. Use proper headings (##), bullet points, and formatting.
+OUTPUT FORMAT:
+Return JSON matching the provided response schema. Do not return markdown.
 
 ORIGINAL CV:
 ${cvText}
@@ -272,11 +276,16 @@ Recommendations: ${matchAnalysis.recommendations.join("; ")}`,
 					],
 				},
 			],
+			config: {
+				responseMimeType: "application/json",
+				responseSchema: TailoredCvResponseSchema,
+			},
 		});
 
 		const text = response.text;
 		if (!text) throw new Error("Empty response from Gemini");
-		return text;
+		const parsed = JSON.parse(text);
+		return TailoredCvSchema.parse(parsed);
 	});
 }
 


### PR DESCRIPTION
## Summary
- Foundation for #7: tailored CV output now has a typed JSON shape (`TailoredCvSchema`) — replaces free-form markdown so DOCX/PDF renderers (issues #10, #11) can apply consistent styling.
- New `jsonToMarkdown` / `markdownToJson` serializer keeps the existing markdown editor UI working (display via JSON→MD, save via MD→JSON).
- Smart migration: nullable `tailoredCvJson` column. Existing markdown rows lazy-backfill JSON on first GET; no forced re-tailor / no API spend.

## Changes
- `prisma/schema.prisma` + migration `20260427004712_add_tailored_cv_json`
- `src/lib/cv-schema.ts` — Zod schema + Gemini `responseSchema` mirror
- `src/lib/cv-serializer.ts` — JSON↔markdown converters
- `src/lib/cv-serializer.test.ts` — round-trip tests
- `src/lib/gemini.ts` — `tailorCV()` returns validated `TailoredCv` via structured output
- `src/app/api/applications/[id]/tailor/route.ts` — persists JSON + markdown
- `src/app/api/applications/[id]/route.ts` — lazy JSON backfill on GET, re-parse on PATCH

## Test plan
- [x] `pnpm exec vitest run src/lib/cv-serializer.test.ts` (3/3 passing)
- [x] `pnpm type-check` clean
- [x] `pnpm exec biome lint` clean on changed files
- [ ] Manual: tailor a new application → verify both `tailoredCV` and `tailoredCvJson` populated
- [ ] Manual: open a legacy application (markdown only) → verify `tailoredCvJson` backfilled
- [ ] Manual: edit tailored CV in UI → save → verify `tailoredCvJson` updated

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured JSON storage for tailored CVs added with automatic backfill from existing markdown.
  * Tailoring now produces validated structured CV objects which are converted to polished markdown for display/editing.
  * New validation/typing for tailored CVs (schema + types) to ensure consistent structured output.

* **Bug Fixes / UX**
  * Editor handling improved to clear invalid/empty content instead of persisting stale data.

* **Tests**
  * Added tests for round-trip conversion, schema validation, HTML-detection, backfill, and editor behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->