### PR TITLE
feat(cv): Gemini context cache for master CV + two-pass self-critique

### DIFF
--- a/prisma/migrations/20260427015623_add_master_cv_gemini_cache/migration.sql
+++ b/prisma/migrations/20260427015623_add_master_cv_gemini_cache/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "MasterCV" ADD COLUMN     "geminiCacheExpiresAt" TIMESTAMP(3),
+ADD COLUMN     "geminiCacheName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,15 +69,17 @@ model Verification {
 // ─── Application Models ───────────────────────────────────────────────
 
 model MasterCV {
-  id               String   @id @default(cuid())
-  userId           String   @unique
-  rawText          String   @db.Text
-  originalFileName String
-  originalFileUrl  String
-  r2Key            String?
-  parsedSections   Json?
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  id                   String    @id @default(cuid())
+  userId               String    @unique
+  rawText              String    @db.Text
+  originalFileName     String
+  originalFileUrl      String
+  r2Key                String?
+  parsedSections       Json?
+  geminiCacheName      String?
+  geminiCacheExpiresAt DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/src/app/api/applications/[id]/tailor/route.ts
+++ b/src/app/api/applications/[id]/tailor/route.ts
@@ -1,10 +1,55 @@
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import type { MatchAnalysis } from "@/lib/gemini";
-import { tailorCV } from "@/lib/gemini";
+import {
+	createCachedMasterCv,
+	extendCachedMasterCv,
+	tailorCV,
+} from "@/lib/gemini";
 import { auth } from "@/lib/auth";
 import { jsonToMarkdown } from "@/lib/cv-serializer";
 import { prisma } from "@/lib/prisma";
+
+const CACHE_REFRESH_SLACK_MS = 5 * 60 * 1000; // refresh if expiring within 5 min
+
+async function ensureMasterCvCache(masterCv: {
+	id: string;
+	rawText: string;
+	geminiCacheName: string | null;
+	geminiCacheExpiresAt: Date | null;
+}): Promise<string | undefined> {
+	const now = Date.now();
+	if (
+		masterCv.geminiCacheName &&
+		masterCv.geminiCacheExpiresAt &&
+		masterCv.geminiCacheExpiresAt.getTime() - now > CACHE_REFRESH_SLACK_MS
+	) {
+		return masterCv.geminiCacheName;
+	}
+
+	if (masterCv.geminiCacheName) {
+		const extendedAt = await extendCachedMasterCv(masterCv.geminiCacheName);
+		if (extendedAt) {
+			await prisma.masterCV.update({
+				where: { id: masterCv.id },
+				data: { geminiCacheExpiresAt: extendedAt },
+			});
+			return masterCv.geminiCacheName;
+		}
+		// Extend failed (likely expired/missing) — fall through and recreate.
+	}
+
+	const created = await createCachedMasterCv(masterCv.id, masterCv.rawText);
+	if (!created) return undefined;
+	await prisma.masterCV.update({
+		where: { id: masterCv.id },
+		data: {
+			geminiCacheName: created.name,
+			geminiCacheExpiresAt: created.expiresAt,
+		},
+	});
+	return created.name;
+}
 
 export async function POST(
 	_request: Request,
@@ -41,11 +86,13 @@ export async function POST(
 	}
 
 	try {
-		const tailoredJson = await tailorCV(
-			masterCV.rawText,
-			application.rawDescription,
-			application.matchAnalysis as unknown as MatchAnalysis,
-		);
+		const cachedContent = await ensureMasterCvCache(masterCV);
+		const tailoredJson = await tailorCV({
+			cvText: masterCV.rawText,
+			jobDescription: application.rawDescription,
+			matchAnalysis: application.matchAnalysis as unknown as MatchAnalysis,
+			cachedContent,
+		});
 		const tailoredMarkdown = jsonToMarkdown(tailoredJson);
 
 		const updated = await prisma.jobApplication.update({

--- a/src/app/api/applications/[id]/tailor/route.ts
+++ b/src/app/api/applications/[id]/tailor/route.ts
@@ -4,7 +4,7 @@ import type { MatchAnalysis } from "@/lib/gemini";
 import {
 	createCachedMasterCv,
 	extendCachedMasterCv,
-	tailorCV,
+	tailorCVWithMeta,
 } from "@/lib/gemini";
 import { auth } from "@/lib/auth";
 import { jsonToMarkdown } from "@/lib/cv-serializer";
@@ -87,12 +87,18 @@ export async function POST(
 
 	try {
 		const cachedContent = await ensureMasterCvCache(masterCV);
-		const tailoredJson = await tailorCV({
+		const { cv: tailoredJson, cacheWasStale } = await tailorCVWithMeta({
 			cvText: masterCV.rawText,
 			jobDescription: application.rawDescription,
 			matchAnalysis: application.matchAnalysis as unknown as MatchAnalysis,
 			cachedContent,
 		});
+		if (cacheWasStale) {
+			await prisma.masterCV.update({
+				where: { id: masterCV.id },
+				data: { geminiCacheName: null, geminiCacheExpiresAt: null },
+			});
+		}
 		const tailoredMarkdown = jsonToMarkdown(tailoredJson);
 
 		const updated = await prisma.jobApplication.update({

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -1,7 +1,7 @@
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { deleteCachedMasterCv } from "@/lib/gemini";
+import { deleteCachedMasterCvStrict } from "@/lib/gemini";
 import { prisma } from "@/lib/prisma";
 import { deleteFileFromR2, extractR2KeyFromUrl } from "@/lib/r2";
 
@@ -49,12 +49,25 @@ export async function DELETE() {
 		return NextResponse.json({ error: "No CV found" }, { status: 404 });
 	}
 
+	// Delete the Gemini cache FIRST, strictly. If it fails for any reason other
+	// than "already gone", surface the error so the user retries — we don't want
+	// to drop the local pointer while personal CV data still lives in the cache.
+	if (masterCV.geminiCacheName) {
+		try {
+			await deleteCachedMasterCvStrict(masterCV.geminiCacheName);
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : "Failed to delete cached CV from Gemini";
+			return NextResponse.json(
+				{ error: `Could not remove cached CV from Gemini: ${message}` },
+				{ status: 502 },
+			);
+		}
+	}
+
 	const r2Key = masterCV.r2Key ?? extractR2KeyFromUrl(masterCV.originalFileUrl);
 	if (r2Key) {
 		await deleteFileFromR2(r2Key);
-	}
-	if (masterCV.geminiCacheName) {
-		await deleteCachedMasterCv(masterCV.geminiCacheName);
 	}
 
 	await prisma.masterCV.delete({ where: { id: masterCV.id } });

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -1,6 +1,7 @@
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { deleteCachedMasterCv } from "@/lib/gemini";
 import { prisma } from "@/lib/prisma";
 import { deleteFileFromR2, extractR2KeyFromUrl } from "@/lib/r2";
 
@@ -36,7 +37,12 @@ export async function DELETE() {
 
 	const masterCV = await prisma.masterCV.findUnique({
 		where: { userId: session.user.id },
-		select: { id: true, r2Key: true, originalFileUrl: true },
+		select: {
+			id: true,
+			r2Key: true,
+			originalFileUrl: true,
+			geminiCacheName: true,
+		},
 	});
 
 	if (!masterCV) {
@@ -46,6 +52,9 @@ export async function DELETE() {
 	const r2Key = masterCV.r2Key ?? extractR2KeyFromUrl(masterCV.originalFileUrl);
 	if (r2Key) {
 		await deleteFileFromR2(r2Key);
+	}
+	if (masterCV.geminiCacheName) {
+		await deleteCachedMasterCv(masterCV.geminiCacheName);
 	}
 
 	await prisma.masterCV.delete({ where: { id: masterCV.id } });

--- a/src/app/api/cv/upload/route.ts
+++ b/src/app/api/cv/upload/route.ts
@@ -2,7 +2,7 @@ import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { extractText } from "@/lib/cv-parser";
-import { parseCV } from "@/lib/gemini";
+import { deleteCachedMasterCv, parseCV } from "@/lib/gemini";
 import { prisma } from "@/lib/prisma";
 import { deleteFileFromR2, extractR2KeyFromUrl, getFileFromR2, getR2PublicUrl } from "@/lib/r2";
 import { cvUploadSchema } from "@/lib/validations";
@@ -28,7 +28,7 @@ export async function POST(request: Request) {
 		// 1. Get existing CV info before replacing
 		const existingCV = await prisma.masterCV.findUnique({
 			where: { userId: session.user.id },
-			select: { r2Key: true, originalFileUrl: true },
+			select: { r2Key: true, originalFileUrl: true, geminiCacheName: true },
 		});
 
 		// 2. Fetch new file from R2
@@ -47,6 +47,8 @@ export async function POST(request: Request) {
 			originalFileUrl: getR2PublicUrl(r2Key),
 			r2Key,
 			parsedSections: JSON.parse(JSON.stringify(parsedSections)),
+			geminiCacheName: null,
+			geminiCacheExpiresAt: null,
 		};
 
 		const masterCV = await prisma.masterCV.upsert({
@@ -55,10 +57,13 @@ export async function POST(request: Request) {
 			update: cvData,
 		});
 
-		// 6. Delete old R2 file only after upsert succeeds
+		// 6. Delete old R2 file + Gemini cache only after upsert succeeds
 		const oldR2Key = existingCV?.r2Key ?? extractR2KeyFromUrl(existingCV?.originalFileUrl);
 		if (oldR2Key && oldR2Key !== r2Key) {
 			await deleteFileFromR2(oldR2Key);
+		}
+		if (existingCV?.geminiCacheName) {
+			await deleteCachedMasterCv(existingCV.geminiCacheName);
 		}
 
 		return NextResponse.json({

--- a/src/app/api/settings/account/route.ts
+++ b/src/app/api/settings/account/route.ts
@@ -1,6 +1,7 @@
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { deleteCachedMasterCv } from "@/lib/gemini";
 import { prisma } from "@/lib/prisma";
 import { deleteFileFromR2, extractR2KeyFromUrl } from "@/lib/r2";
 
@@ -10,14 +11,17 @@ export async function DELETE() {
 		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 	}
 
-	// Clean up R2 files before deleting user
+	// Clean up R2 files + Gemini cache before deleting user
 	const masterCV = await prisma.masterCV.findUnique({
 		where: { userId: session.user.id },
-		select: { r2Key: true, originalFileUrl: true },
+		select: { r2Key: true, originalFileUrl: true, geminiCacheName: true },
 	});
 	const r2Key = masterCV?.r2Key ?? extractR2KeyFromUrl(masterCV?.originalFileUrl);
 	if (r2Key) {
 		await deleteFileFromR2(r2Key);
+	}
+	if (masterCV?.geminiCacheName) {
+		await deleteCachedMasterCv(masterCV.geminiCacheName);
 	}
 
 	// Cascading delete: User model has onDelete: Cascade on all relations

--- a/src/app/api/settings/account/route.ts
+++ b/src/app/api/settings/account/route.ts
@@ -1,7 +1,7 @@
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { deleteCachedMasterCv } from "@/lib/gemini";
+import { deleteCachedMasterCvStrict } from "@/lib/gemini";
 import { prisma } from "@/lib/prisma";
 import { deleteFileFromR2, extractR2KeyFromUrl } from "@/lib/r2";
 
@@ -11,17 +11,28 @@ export async function DELETE() {
 		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 	}
 
-	// Clean up R2 files + Gemini cache before deleting user
+	// Clean up Gemini cache FIRST, strictly. If it fails (other than "already
+	// gone"), surface the error rather than orphaning personal CV data in the
+	// third-party cache after we've dropped the local user record.
 	const masterCV = await prisma.masterCV.findUnique({
 		where: { userId: session.user.id },
 		select: { r2Key: true, originalFileUrl: true, geminiCacheName: true },
 	});
+	if (masterCV?.geminiCacheName) {
+		try {
+			await deleteCachedMasterCvStrict(masterCV.geminiCacheName);
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : "Failed to delete cached CV from Gemini";
+			return NextResponse.json(
+				{ error: `Could not remove cached CV from Gemini: ${message}` },
+				{ status: 502 },
+			);
+		}
+	}
 	const r2Key = masterCV?.r2Key ?? extractR2KeyFromUrl(masterCV?.originalFileUrl);
 	if (r2Key) {
 		await deleteFileFromR2(r2Key);
-	}
-	if (masterCV?.geminiCacheName) {
-		await deleteCachedMasterCv(masterCV.geminiCacheName);
 	}
 
 	// Cascading delete: User model has onDelete: Cascade on all relations

--- a/src/lib/gemini-tailor-wiring.test.ts
+++ b/src/lib/gemini-tailor-wiring.test.ts
@@ -139,8 +139,12 @@ describe("tailorCV wiring", () => {
 });
 
 describe("master CV cache lifecycle", () => {
-	it("createCachedMasterCv returns name + expiry on success", async () => {
-		cachesCreate.mockResolvedValue({ name: "cachedContents/xyz" });
+	it("createCachedMasterCv returns name + server expireTime on success", async () => {
+		const serverExpiry = "2030-01-02T03:04:05Z";
+		cachesCreate.mockResolvedValue({
+			name: "cachedContents/xyz",
+			expireTime: serverExpiry,
+		});
 		const { createCachedMasterCv } = await import("@/lib/gemini");
 
 		const result = await createCachedMasterCv("master-1", "raw text".repeat(100));
@@ -150,7 +154,19 @@ describe("master CV cache lifecycle", () => {
 		expect(params.config.ttl).toMatch(/^\d+s$/);
 		expect(params.config.systemInstruction).toBeDefined();
 		expect(result?.name).toBe("cachedContents/xyz");
-		expect(result?.expiresAt).toBeInstanceOf(Date);
+		expect(result?.expiresAt.toISOString()).toBe(new Date(serverExpiry).toISOString());
+	});
+
+	it("createCachedMasterCv falls back to TTL-based expiry when server omits expireTime", async () => {
+		cachesCreate.mockResolvedValue({ name: "cachedContents/xyz" });
+		const { createCachedMasterCv } = await import("@/lib/gemini");
+
+		const before = Date.now();
+		const result = await createCachedMasterCv("master-1", "raw");
+		const after = Date.now();
+
+		expect(result?.expiresAt.getTime()).toBeGreaterThanOrEqual(before);
+		expect(result?.expiresAt.getTime()).toBeLessThanOrEqual(after + 3600 * 1000 + 50);
 	});
 
 	it("createCachedMasterCv returns null on SDK failure (graceful fallback)", async () => {
@@ -163,6 +179,30 @@ describe("master CV cache lifecycle", () => {
 		expect(result).toBeNull();
 	});
 
+	it("extendCachedMasterCv returns server expireTime on success", async () => {
+		const serverExpiry = "2030-06-01T00:00:00Z";
+		cachesUpdate.mockResolvedValue({ expireTime: serverExpiry });
+		const { extendCachedMasterCv } = await import("@/lib/gemini");
+
+		const result = await extendCachedMasterCv("cachedContents/xyz");
+
+		expect(cachesUpdate).toHaveBeenCalledWith({
+			name: "cachedContents/xyz",
+			config: { ttl: expect.stringMatching(/^\d+s$/) },
+		});
+		expect(result?.toISOString()).toBe(new Date(serverExpiry).toISOString());
+	});
+
+	it("extendCachedMasterCv returns null on SDK failure", async () => {
+		cachesUpdate.mockRejectedValue(new Error("not found"));
+		const { extendCachedMasterCv } = await import("@/lib/gemini");
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const result = await extendCachedMasterCv("cachedContents/xyz");
+
+		expect(result).toBeNull();
+	});
+
 	it("deleteCachedMasterCv calls SDK delete and swallows errors", async () => {
 		cachesDelete.mockResolvedValue({});
 		const { deleteCachedMasterCv } = await import("@/lib/gemini");
@@ -170,5 +210,69 @@ describe("master CV cache lifecycle", () => {
 		await deleteCachedMasterCv("cachedContents/xyz");
 
 		expect(cachesDelete).toHaveBeenCalledWith({ name: "cachedContents/xyz" });
+	});
+
+	it("deleteCachedMasterCvStrict throws on real failures", async () => {
+		cachesDelete.mockRejectedValue(new Error("network down"));
+		const { deleteCachedMasterCvStrict } = await import("@/lib/gemini");
+
+		await expect(deleteCachedMasterCvStrict("cachedContents/xyz")).rejects.toThrow(
+			/network down/,
+		);
+	});
+
+	it("deleteCachedMasterCvStrict treats not-found as success", async () => {
+		cachesDelete.mockRejectedValue(new Error("HTTP 404 not found"));
+		const { deleteCachedMasterCvStrict } = await import("@/lib/gemini");
+
+		await expect(
+			deleteCachedMasterCvStrict("cachedContents/xyz"),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe("stale cachedContent fallback", () => {
+	it("retries with inline CV when cached content is reported missing", async () => {
+		const draft = { ...validTailoredCv, summary: "Inline draft" };
+		generateContent
+			.mockRejectedValueOnce(new Error("CachedContent not found: cachedContents/old"))
+			.mockResolvedValueOnce({ text: JSON.stringify(draft) });
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const { tailorCVWithMeta } = await import("@/lib/gemini");
+
+		const result = await tailorCVWithMeta({
+			cvText: "FULL CV BODY",
+			jobDescription: "JD",
+			matchAnalysis: emptyMatch,
+			cachedContent: "cachedContents/old",
+			skipCritique: true,
+		});
+
+		expect(generateContent).toHaveBeenCalledTimes(2);
+		const firstCall = generateContent.mock.calls[0][0];
+		const secondCall = generateContent.mock.calls[1][0];
+		expect(firstCall.config.cachedContent).toBe("cachedContents/old");
+		expect(secondCall.config.cachedContent).toBeUndefined();
+		expect(secondCall.config.systemInstruction).toBeDefined();
+		expect(secondCall.contents[0].parts[0].text).toContain("ORIGINAL CV:\nFULL CV BODY");
+		expect(result.cv.summary).toBe("Inline draft");
+		expect(result.cacheWasStale).toBe(true);
+	});
+
+	it("does not fall back when error is unrelated to cache", async () => {
+		generateContent.mockRejectedValue(new Error("rate limit exceeded"));
+
+		const { tailorCVWithMeta } = await import("@/lib/gemini");
+
+		await expect(
+			tailorCVWithMeta({
+				cvText: "CV",
+				jobDescription: "JD",
+				matchAnalysis: emptyMatch,
+				cachedContent: "cachedContents/old",
+				skipCritique: true,
+			}),
+		).rejects.toThrow(/rate limit/);
 	});
 });

--- a/src/lib/gemini-tailor-wiring.test.ts
+++ b/src/lib/gemini-tailor-wiring.test.ts
@@ -1,10 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MatchAnalysis } from "@/lib/gemini";
 
 const generateContent = vi.fn();
+const cachesCreate = vi.fn();
+const cachesUpdate = vi.fn();
+const cachesDelete = vi.fn();
 
 vi.mock("@google/genai", () => ({
 	GoogleGenAI: class {
 		models = { generateContent };
+		caches = {
+			create: cachesCreate,
+			update: cachesUpdate,
+			delete: cachesDelete,
+		};
 	},
 }));
 
@@ -18,21 +27,31 @@ const validTailoredCv = {
 	certifications: [],
 };
 
-describe("tailorCV wiring", () => {
-	beforeEach(() => {
-		generateContent.mockReset();
-		generateContent.mockResolvedValue({ text: JSON.stringify(validTailoredCv) });
-	});
+const emptyMatch: MatchAnalysis = {
+	matchScore: 0,
+	summary: "",
+	matchedSkills: [],
+	missingSkills: [],
+	recommendations: [],
+};
 
-	it("passes TAILOR_SYSTEM_INSTRUCTION via config.systemInstruction", async () => {
+beforeEach(() => {
+	generateContent.mockReset();
+	cachesCreate.mockReset();
+	cachesUpdate.mockReset();
+	cachesDelete.mockReset();
+	generateContent.mockResolvedValue({ text: JSON.stringify(validTailoredCv) });
+});
+
+describe("tailorCV wiring", () => {
+	it("passes TAILOR_SYSTEM_INSTRUCTION via config.systemInstruction on draft", async () => {
 		const { tailorCV, TAILOR_SYSTEM_INSTRUCTION } = await import("@/lib/gemini");
 
-		await tailorCV("CV TEXT", "JD TEXT", {
-			matchScore: 0,
-			summary: "",
-			matchedSkills: [],
-			missingSkills: [],
-			recommendations: [],
+		await tailorCV({
+			cvText: "CV TEXT",
+			jobDescription: "JD TEXT",
+			matchAnalysis: emptyMatch,
+			skipCritique: true,
 		});
 
 		expect(generateContent).toHaveBeenCalledTimes(1);
@@ -40,17 +59,20 @@ describe("tailorCV wiring", () => {
 		expect(call.config.systemInstruction).toBe(TAILOR_SYSTEM_INSTRUCTION);
 		expect(call.config.responseMimeType).toBe("application/json");
 		expect(call.config.responseSchema).toBeDefined();
+		expect(call.config.cachedContent).toBeUndefined();
 	});
 
 	it("passes the user prompt (CV + JD + match analysis) as user content", async () => {
 		const { tailorCV } = await import("@/lib/gemini");
 
-		await tailorCV("CV BODY", "JD BODY", {
-			matchScore: 0,
-			summary: "",
-			matchedSkills: [{ skill: "TypeScript", evidence: "", relevance: "high" }],
-			missingSkills: [],
-			recommendations: [],
+		await tailorCV({
+			cvText: "CV BODY",
+			jobDescription: "JD BODY",
+			matchAnalysis: {
+				...emptyMatch,
+				matchedSkills: [{ skill: "TypeScript", evidence: "", relevance: "high" }],
+			},
+			skipCritique: true,
 		});
 
 		const call = generateContent.mock.calls[0][0];
@@ -59,5 +81,94 @@ describe("tailorCV wiring", () => {
 		expect(text).toContain("ORIGINAL CV:\nCV BODY");
 		expect(text).toContain("JOB DESCRIPTION:\nJD BODY");
 		expect(text).toContain("Matched skills: TypeScript");
+	});
+
+	it("uses cachedContent and omits CV from user prompt when provided", async () => {
+		const { tailorCV } = await import("@/lib/gemini");
+
+		await tailorCV({
+			cvText: "CV BODY",
+			jobDescription: "JD BODY",
+			matchAnalysis: emptyMatch,
+			cachedContent: "cachedContents/abc123",
+			skipCritique: true,
+		});
+
+		const call = generateContent.mock.calls[0][0];
+		expect(call.config.cachedContent).toBe("cachedContents/abc123");
+		expect(call.config.systemInstruction).toBeUndefined();
+		const text = call.contents[0].parts[0].text as string;
+		expect(text).not.toContain("ORIGINAL CV:");
+		expect(text).toContain("JOB DESCRIPTION:\nJD BODY");
+	});
+
+	it("runs the critique pass by default and returns its revised CV", async () => {
+		const draft = { ...validTailoredCv, summary: "Draft summary" };
+		const revised = { ...validTailoredCv, summary: "Revised summary" };
+		generateContent
+			.mockResolvedValueOnce({ text: JSON.stringify(draft) })
+			.mockResolvedValueOnce({ text: JSON.stringify(revised) });
+
+		const { tailorCV, TAILOR_CRITIQUE_SYSTEM_INSTRUCTION } = await import(
+			"@/lib/gemini"
+		);
+
+		const out = await tailorCV({
+			cvText: "CV",
+			jobDescription: "JD",
+			matchAnalysis: emptyMatch,
+		});
+
+		expect(generateContent).toHaveBeenCalledTimes(2);
+		expect(generateContent.mock.calls[1][0].config.systemInstruction).toBe(
+			TAILOR_CRITIQUE_SYSTEM_INSTRUCTION,
+		);
+		expect(out.summary).toBe("Revised summary");
+	});
+
+	it("skipCritique=true runs only one generateContent call", async () => {
+		const { tailorCV } = await import("@/lib/gemini");
+		await tailorCV({
+			cvText: "CV",
+			jobDescription: "JD",
+			matchAnalysis: emptyMatch,
+			skipCritique: true,
+		});
+		expect(generateContent).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("master CV cache lifecycle", () => {
+	it("createCachedMasterCv returns name + expiry on success", async () => {
+		cachesCreate.mockResolvedValue({ name: "cachedContents/xyz" });
+		const { createCachedMasterCv } = await import("@/lib/gemini");
+
+		const result = await createCachedMasterCv("master-1", "raw text".repeat(100));
+
+		expect(cachesCreate).toHaveBeenCalledTimes(1);
+		const params = cachesCreate.mock.calls[0][0];
+		expect(params.config.ttl).toMatch(/^\d+s$/);
+		expect(params.config.systemInstruction).toBeDefined();
+		expect(result?.name).toBe("cachedContents/xyz");
+		expect(result?.expiresAt).toBeInstanceOf(Date);
+	});
+
+	it("createCachedMasterCv returns null on SDK failure (graceful fallback)", async () => {
+		cachesCreate.mockRejectedValue(new Error("content too small"));
+		const { createCachedMasterCv } = await import("@/lib/gemini");
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const result = await createCachedMasterCv("master-1", "tiny");
+
+		expect(result).toBeNull();
+	});
+
+	it("deleteCachedMasterCv calls SDK delete and swallows errors", async () => {
+		cachesDelete.mockResolvedValue({});
+		const { deleteCachedMasterCv } = await import("@/lib/gemini");
+
+		await deleteCachedMasterCv("cachedContents/xyz");
+
+		expect(cachesDelete).toHaveBeenCalledWith({ name: "cachedContents/xyz" });
 	});
 });

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -315,6 +315,16 @@ export interface MasterCvCacheResult {
  * transient SDK error). Callers should treat null as "no cache available" and
  * fall back to inline CV in the user prompt.
  */
+function fallbackExpiry(): Date {
+	return new Date(Date.now() + MASTER_CV_CACHE_TTL_SECONDS * 1000);
+}
+
+function parseExpireTime(expireTime: string | undefined): Date {
+	if (!expireTime) return fallbackExpiry();
+	const parsed = new Date(expireTime);
+	return Number.isNaN(parsed.getTime()) ? fallbackExpiry() : parsed;
+}
+
 export async function createCachedMasterCv(
 	masterCvId: string,
 	rawText: string,
@@ -334,10 +344,7 @@ export async function createCachedMasterCv(
 			},
 		});
 		if (!cache.name) return null;
-		return {
-			name: cache.name,
-			expiresAt: new Date(Date.now() + MASTER_CV_CACHE_TTL_SECONDS * 1000),
-		};
+		return { name: cache.name, expiresAt: parseExpireTime(cache.expireTime) };
 	} catch (err) {
 		console.warn(
 			`[tailor] master CV cache create failed (id=${masterCvId}): ${err instanceof Error ? err.message : String(err)}`,
@@ -348,11 +355,11 @@ export async function createCachedMasterCv(
 
 export async function extendCachedMasterCv(name: string): Promise<Date | null> {
 	try {
-		await ai.caches.update({
+		const updated = await ai.caches.update({
 			name,
 			config: { ttl: `${MASTER_CV_CACHE_TTL_SECONDS}s` },
 		});
-		return new Date(Date.now() + MASTER_CV_CACHE_TTL_SECONDS * 1000);
+		return parseExpireTime(updated.expireTime);
 	} catch (err) {
 		console.warn(
 			`[tailor] master CV cache extend failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -361,6 +368,10 @@ export async function extendCachedMasterCv(name: string): Promise<Date | null> {
 	}
 }
 
+/**
+ * Best-effort delete (logs and swallows). Use for replacement flows where the
+ * old cache becomes a no-op leaked resource — Gemini will TTL it anyway.
+ */
 export async function deleteCachedMasterCv(name: string): Promise<void> {
 	try {
 		await ai.caches.delete({ name });
@@ -368,6 +379,18 @@ export async function deleteCachedMasterCv(name: string): Promise<void> {
 		console.warn(
 			`[tailor] master CV cache delete failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
+	}
+}
+
+/** Strict variant: rejects on failure unless cache is already gone (404 / not found). */
+export async function deleteCachedMasterCvStrict(name: string): Promise<void> {
+	try {
+		await ai.caches.delete({ name });
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		// Treat "already gone" as success — the desired end state is achieved.
+		if (/not found|404/i.test(message)) return;
+		throw err;
 	}
 }
 
@@ -408,14 +431,20 @@ interface TailorOnceInput {
 	cachedContent?: string;
 }
 
-async function tailorDraft(
-	input: TailorOnceInput,
-): Promise<{ cv: TailoredCv; usage: UsageInfo }> {
+/** Errors from Gemini that mean the cachedContent ref is gone server-side. */
+export function isStaleCacheError(err: unknown): boolean {
+	const message = err instanceof Error ? err.message : String(err);
+	return /cached.?content.*not.?found|cached.?content.*expired|cached.?content.*invalid|404/i.test(
+		message,
+	);
+}
+
+async function generateDraft(input: TailorOnceInput) {
 	const userText = input.cachedContent
 		? buildTailorUserPromptCached(input.jobDescription, input.matchAnalysis)
 		: buildTailorUserPrompt(input.cvText, input.jobDescription, input.matchAnalysis);
 
-	const response = await ai.models.generateContent({
+	return ai.models.generateContent({
 		model: MODEL,
 		contents: [{ role: "user", parts: [{ text: userText }] }],
 		config: {
@@ -426,12 +455,33 @@ async function tailorDraft(
 			responseSchema: TailoredCvResponseSchema,
 		},
 	});
+}
+
+async function tailorDraft(
+	input: TailorOnceInput,
+): Promise<{ cv: TailoredCv; usage: UsageInfo; cacheWasStale: boolean }> {
+	let response: Awaited<ReturnType<typeof generateDraft>>;
+	let cacheWasStale = false;
+	try {
+		response = await generateDraft(input);
+	} catch (err) {
+		if (input.cachedContent && isStaleCacheError(err)) {
+			console.warn(
+				`[tailor] cached content ${input.cachedContent} is stale — retrying with inline CV`,
+			);
+			cacheWasStale = true;
+			response = await generateDraft({ ...input, cachedContent: undefined });
+		} else {
+			throw err;
+		}
+	}
 
 	const text = response.text;
 	if (!text) throw new Error("Empty response from Gemini");
 	return {
 		cv: TailoredCvSchema.parse(JSON.parse(text)),
 		usage: readUsage(response.usageMetadata),
+		cacheWasStale,
 	};
 }
 
@@ -500,17 +550,32 @@ export interface TailorCvInput {
 	skipCritique?: boolean;
 }
 
+export interface TailorCvResult {
+	cv: TailoredCv;
+	/** True when the supplied cachedContent ref was stale and the call fell back to inline CV. */
+	cacheWasStale: boolean;
+}
+
 export async function tailorCV(input: TailorCvInput): Promise<TailoredCv> {
+	const result = await tailorCVWithMeta(input);
+	return result.cv;
+}
+
+/** Same as tailorCV but exposes whether the cache had to be invalidated, so callers can update DB metadata. */
+export async function tailorCVWithMeta(input: TailorCvInput): Promise<TailorCvResult> {
 	return withRetry(async () => {
 		const draft = await tailorDraft(input);
 		logUsage("draft", draft.usage);
 
 		const skipCritique = input.skipCritique ?? process.env.TAILOR_SKIP_CRITIQUE === "1";
-		if (skipCritique) return draft.cv;
+		if (skipCritique) return { cv: draft.cv, cacheWasStale: draft.cacheWasStale };
 
+		// NOTE: critique always inlines ORIGINAL CV. Reusing the draft cache would
+		// require the cache to omit systemInstruction (since critique uses a
+		// different one). Tracked for future optimization.
 		const revised = await critiqueTailoredCv(input.cvText, input.jobDescription, draft.cv);
 		logUsage("critique", revised.usage);
-		return revised.cv;
+		return { cv: revised.cv, cacheWasStale: draft.cacheWasStale };
 	});
 }
 

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -237,6 +237,9 @@ ${jobDescription}`,
 /** Hard cap on CV text passed to the tailor prompt to bound token cost. */
 export const MAX_TAILOR_CV_CHARS = 30_000;
 
+/** TTL for the master-CV Gemini context cache. */
+export const MASTER_CV_CACHE_TTL_SECONDS = 3600;
+
 /**
  * System instruction for tailorCV. RULE 4 (Markdown bold inside bullets) is a
  * load-bearing contract with the DOCX/PDF renderers — see issues #10 and #11.
@@ -265,6 +268,13 @@ Each experience and project bullet must:
 OUTPUT
 Return JSON matching the provided response schema. Do not return markdown, explanations, or commentary outside the schema. Reorder \`experience\` so the most JD-relevant role appears first.`;
 
+function formatMatchAnalysis(matchAnalysis: MatchAnalysis): string {
+	return `MATCH ANALYSIS:
+Matched skills: ${matchAnalysis.matchedSkills.map((s) => s.skill).join(", ")}
+Missing skills: ${matchAnalysis.missingSkills.map((s) => s.skill).join(", ")}
+Recommendations: ${matchAnalysis.recommendations.join("; ")}`;
+}
+
 export function buildTailorUserPrompt(
 	cvText: string,
 	jobDescription: string,
@@ -278,39 +288,229 @@ ${boundedCv}
 JOB DESCRIPTION:
 ${jobDescription}
 
-MATCH ANALYSIS:
-Matched skills: ${matchAnalysis.matchedSkills.map((s) => s.skill).join(", ")}
-Missing skills: ${matchAnalysis.missingSkills.map((s) => s.skill).join(", ")}
-Recommendations: ${matchAnalysis.recommendations.join("; ")}`;
+${formatMatchAnalysis(matchAnalysis)}`;
 }
 
-export async function tailorCV(
-	cvText: string,
+/** Used when ORIGINAL CV is supplied via Gemini context cache. */
+export function buildTailorUserPromptCached(
 	jobDescription: string,
 	matchAnalysis: MatchAnalysis,
-): Promise<TailoredCv> {
-	return withRetry(async () => {
-		const response = await ai.models.generateContent({
+): string {
+	return `JOB DESCRIPTION:
+${jobDescription}
+
+${formatMatchAnalysis(matchAnalysis)}`;
+}
+
+// ─── Master CV cache lifecycle ───────────────────────────────────────
+
+export interface MasterCvCacheResult {
+	name: string;
+	expiresAt: Date;
+}
+
+/**
+ * Create a Gemini context cache holding ORIGINAL CV + system instruction.
+ * Returns null on failure (e.g. content below the model's minimum cache size,
+ * transient SDK error). Callers should treat null as "no cache available" and
+ * fall back to inline CV in the user prompt.
+ */
+export async function createCachedMasterCv(
+	masterCvId: string,
+	rawText: string,
+): Promise<MasterCvCacheResult | null> {
+	const boundedCv =
+		rawText.length > MAX_TAILOR_CV_CHARS ? rawText.slice(0, MAX_TAILOR_CV_CHARS) : rawText;
+	try {
+		const cache = await ai.caches.create({
 			model: MODEL,
-			contents: [
-				{
-					role: "user",
-					parts: [
-						{ text: buildTailorUserPrompt(cvText, jobDescription, matchAnalysis) },
-					],
-				},
-			],
 			config: {
+				contents: [
+					{ role: "user", parts: [{ text: `ORIGINAL CV:\n${boundedCv}` }] },
+				],
 				systemInstruction: TAILOR_SYSTEM_INSTRUCTION,
-				responseMimeType: "application/json",
-				responseSchema: TailoredCvResponseSchema,
+				ttl: `${MASTER_CV_CACHE_TTL_SECONDS}s`,
+				displayName: `master-cv-${masterCvId}`,
 			},
 		});
+		if (!cache.name) return null;
+		return {
+			name: cache.name,
+			expiresAt: new Date(Date.now() + MASTER_CV_CACHE_TTL_SECONDS * 1000),
+		};
+	} catch (err) {
+		console.warn(
+			`[tailor] master CV cache create failed (id=${masterCvId}): ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return null;
+	}
+}
 
-		const text = response.text;
-		if (!text) throw new Error("Empty response from Gemini");
-		const parsed = JSON.parse(text);
-		return TailoredCvSchema.parse(parsed);
+export async function extendCachedMasterCv(name: string): Promise<Date | null> {
+	try {
+		await ai.caches.update({
+			name,
+			config: { ttl: `${MASTER_CV_CACHE_TTL_SECONDS}s` },
+		});
+		return new Date(Date.now() + MASTER_CV_CACHE_TTL_SECONDS * 1000);
+	} catch (err) {
+		console.warn(
+			`[tailor] master CV cache extend failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return null;
+	}
+}
+
+export async function deleteCachedMasterCv(name: string): Promise<void> {
+	try {
+		await ai.caches.delete({ name });
+	} catch (err) {
+		console.warn(
+			`[tailor] master CV cache delete failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
+}
+
+// ─── Tailor (with optional cache + self-critique) ────────────────────
+
+interface UsageInfo {
+	promptTokens?: number;
+	cachedTokens?: number;
+	outputTokens?: number;
+}
+
+function readUsage(meta: unknown): UsageInfo {
+	const m = meta as
+		| {
+				promptTokenCount?: number;
+				cachedContentTokenCount?: number;
+				candidatesTokenCount?: number;
+		  }
+		| undefined;
+	return {
+		promptTokens: m?.promptTokenCount,
+		cachedTokens: m?.cachedContentTokenCount,
+		outputTokens: m?.candidatesTokenCount,
+	};
+}
+
+function logUsage(label: string, usage: UsageInfo): void {
+	if (process.env.TAILOR_LOG_USAGE === "0") return;
+	console.log(
+		`[tailor] ${label} prompt=${usage.promptTokens ?? "?"} cached=${usage.cachedTokens ?? 0} output=${usage.outputTokens ?? "?"}`,
+	);
+}
+
+interface TailorOnceInput {
+	cvText: string;
+	jobDescription: string;
+	matchAnalysis: MatchAnalysis;
+	cachedContent?: string;
+}
+
+async function tailorDraft(
+	input: TailorOnceInput,
+): Promise<{ cv: TailoredCv; usage: UsageInfo }> {
+	const userText = input.cachedContent
+		? buildTailorUserPromptCached(input.jobDescription, input.matchAnalysis)
+		: buildTailorUserPrompt(input.cvText, input.jobDescription, input.matchAnalysis);
+
+	const response = await ai.models.generateContent({
+		model: MODEL,
+		contents: [{ role: "user", parts: [{ text: userText }] }],
+		config: {
+			...(input.cachedContent
+				? { cachedContent: input.cachedContent }
+				: { systemInstruction: TAILOR_SYSTEM_INSTRUCTION }),
+			responseMimeType: "application/json",
+			responseSchema: TailoredCvResponseSchema,
+		},
+	});
+
+	const text = response.text;
+	if (!text) throw new Error("Empty response from Gemini");
+	return {
+		cv: TailoredCvSchema.parse(JSON.parse(text)),
+		usage: readUsage(response.usageMetadata),
+	};
+}
+
+export const TAILOR_CRITIQUE_SYSTEM_INSTRUCTION = `You are reviewing a tailored CV draft for truthfulness and JD alignment.
+
+Your task:
+1. For each experience and project bullet in DRAFT, verify it traces to ORIGINAL CV. Remove or rewrite any bullet that fabricates skills, metrics, employers, or accomplishments.
+2. Check keyword coverage: ensure 70–80% of JOB DESCRIPTION's hard skills appear naturally in the revised CV where supported by ORIGINAL CV.
+3. Verify each bullet starts with a strong past-tense action verb and stays under 25 words. Trim or rewrite as needed.
+4. Verify markdown \`**bold**\` is applied sparingly to JD-aligned terms only.
+5. If DRAFT is already correct, return it unchanged.
+
+Return JSON matching the provided response schema. Do not return commentary.`;
+
+export function buildCritiquePrompt(
+	cvText: string,
+	jobDescription: string,
+	draft: TailoredCv,
+): string {
+	const boundedCv =
+		cvText.length > MAX_TAILOR_CV_CHARS ? cvText.slice(0, MAX_TAILOR_CV_CHARS) : cvText;
+	return `ORIGINAL CV:
+${boundedCv}
+
+JOB DESCRIPTION:
+${jobDescription}
+
+DRAFT (JSON to review and revise):
+${JSON.stringify(draft, null, 2)}`;
+}
+
+async function critiqueTailoredCv(
+	cvText: string,
+	jobDescription: string,
+	draft: TailoredCv,
+): Promise<{ cv: TailoredCv; usage: UsageInfo }> {
+	const response = await ai.models.generateContent({
+		model: MODEL,
+		contents: [
+			{
+				role: "user",
+				parts: [{ text: buildCritiquePrompt(cvText, jobDescription, draft) }],
+			},
+		],
+		config: {
+			systemInstruction: TAILOR_CRITIQUE_SYSTEM_INSTRUCTION,
+			responseMimeType: "application/json",
+			responseSchema: TailoredCvResponseSchema,
+		},
+	});
+	const text = response.text;
+	if (!text) throw new Error("Empty response from Gemini critique");
+	return {
+		cv: TailoredCvSchema.parse(JSON.parse(text)),
+		usage: readUsage(response.usageMetadata),
+	};
+}
+
+export interface TailorCvInput {
+	cvText: string;
+	jobDescription: string;
+	matchAnalysis: MatchAnalysis;
+	/** Resource name from createCachedMasterCv. When present, CV is supplied via cache. */
+	cachedContent?: string;
+	/** Skip the critique pass (cost-sensitive flows). Defaults to env TAILOR_SKIP_CRITIQUE === "1". */
+	skipCritique?: boolean;
+}
+
+export async function tailorCV(input: TailorCvInput): Promise<TailoredCv> {
+	return withRetry(async () => {
+		const draft = await tailorDraft(input);
+		logUsage("draft", draft.usage);
+
+		const skipCritique = input.skipCritique ?? process.env.TAILOR_SKIP_CRITIQUE === "1";
+		if (skipCritique) return draft.cv;
+
+		const revised = await critiqueTailoredCv(input.cvText, input.jobDescription, draft.cv);
+		logUsage("critique", revised.usage);
+		return revised.cv;
 	});
 }
 


### PR DESCRIPTION
## Summary
Two complementary improvements to the tailor pipeline:

**Caching.** Master CV is now uploaded once into a Gemini context cache (\`ai.caches.create\`) and reused across tailoring calls. Cache name + expiry stored on \`MasterCV\`. Subsequent tailorings reference the cache rather than resending the full CV, cutting input-token cost. Cache is auto-extended on use, recreated on expiry, and invalidated on master CV upsert / delete / account delete. Cache create failures (e.g. CV below model's minimum cache token threshold) degrade gracefully to inline-CV mode with a console warn.

**Self-critique.** After the draft pass, a second \`generateContent\` call with \`TAILOR_CRITIQUE_SYSTEM_INSTRUCTION\` re-checks each bullet against ORIGINAL CV (truthfulness), against JD coverage (RULE 3), and against bullet style (RULE 5). Returns a revised \`TailoredCv\`. Skippable via \`skipCritique\` flag on the call or \`TAILOR_SKIP_CRITIQUE=1\` env.

**Observability.** Per-pass logging of \`promptTokens\` / \`cachedTokens\` / \`outputTokens\` so cache savings are measurable. Disable with \`TAILOR_LOG_USAGE=0\`.

## Breaking change
\`tailorCV()\` signature changes from positional args to an options object:

```ts
// before
tailorCV(cvText, jobDescription, matchAnalysis)
// after
tailorCV({ cvText, jobDescription, matchAnalysis, cachedContent?, skipCritique? })
```

All in-tree callers updated.

## Migration
\`20260427015623_add_master_cv_gemini_cache\` adds nullable \`geminiCacheName\` + \`geminiCacheExpiresAt\` on \`MasterCV\`. Existing rows unaffected; cache populates lazily on next tailor.

## Test plan
- [x] \`pnpm exec vitest run src/lib src/app/api\` (22/22 pass — covers wiring, cache create/delete, critique on/off, cachedContent path)
- [x] \`pnpm type-check\` clean
- [x] Biome lint clean on changed files
- [ ] Manual: tailor twice in a row, observe \`cached=...\` token count > 0 on the second call
- [ ] Manual: re-upload master CV, verify old \`geminiCacheName\` is deleted from Prisma row and old cache resource is removed via Gemini delete

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Master CV context caching to improve tailoring performance.
  * Added critique stage to CV tailoring workflow for enhanced customization.

* **Chores**
  * Updated database schema to support caching metadata.
  * Enhanced cache cleanup during CV and account deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->