### PR TITLE
feat(export): rewrite DOCX renderer — Calibri, 0.75" margins, hyperlinks, inline emphasis

### DIFF
--- a/src/app/api/applications/[id]/export/route.ts
+++ b/src/app/api/applications/[id]/export/route.ts
@@ -2,7 +2,7 @@ import { headers } from "next/headers";
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { TailoredCvSchema } from "@/lib/cv-schema";
-import { markdownToJson } from "@/lib/cv-serializer";
+import { jsonToMarkdown, looksLikeHtml, markdownToJson } from "@/lib/cv-serializer";
 import { generateCvDocx, generateDocx, markdownToPlainText } from "@/lib/export";
 import { prisma } from "@/lib/prisma";
 
@@ -24,11 +24,15 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 	const type = request.nextUrl.searchParams.get("type") ?? "cv";
 	const isCoverLetter = type === "cover-letter";
 
-	const markdown = isCoverLetter
+	const rawMarkdown = isCoverLetter
 		? application.coverLetter
 		: (application.tailoredCVEdited ?? application.tailoredCV);
+	// Treat HTML- or whitespace-only content as "no markdown" so the route never
+	// falls back to a renderer that would emit raw tags or a blank file.
+	const usableMarkdown = isUsableMarkdown(rawMarkdown) ? rawMarkdown : null;
+	const cv = isCoverLetter ? null : resolveTailoredCv(application.tailoredCvJson, usableMarkdown);
 
-	if (!markdown && (isCoverLetter || !application.tailoredCvJson)) {
+	if (!usableMarkdown && !cv) {
 		return NextResponse.json(
 			{ error: `No ${isCoverLetter ? "cover letter" : "tailored CV"} to export` },
 			{ status: 400 },
@@ -42,12 +46,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 	if (format === "docx") {
 		let buffer: Buffer;
 		if (isCoverLetter) {
-			buffer = await generateDocx(markdown ?? "", `Cover Letter - ${application.title}`);
+			// Guarded above — usableMarkdown is non-null here.
+			buffer = await generateDocx(usableMarkdown as string, `Cover Letter - ${application.title}`);
+		} else if (cv) {
+			buffer = await generateCvDocx(cv, `${application.title} - Tailored CV`);
 		} else {
-			const cv = resolveTailoredCv(application.tailoredCvJson, markdown);
-			buffer = cv
-				? await generateCvDocx(cv, `${application.title} - Tailored CV`)
-				: await generateDocx(markdown ?? "", `${application.title} - Tailored CV`);
+			// Last resort: validated non-HTML markdown CV with no parseable JSON.
+			buffer = await generateDocx(usableMarkdown as string, `${application.title} - Tailored CV`);
 		}
 
 		return new NextResponse(new Uint8Array(buffer), {
@@ -58,14 +63,24 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 		});
 	}
 
-	// Plain text fallback (for PDF, client will handle rendering)
-	const plainText = markdownToPlainText(markdown ?? "");
+	// Plain text fallback (for PDF, client will handle rendering). When the row
+	// has only structured JSON (no edited markdown), serialize the JSON first so
+	// the response isn't an empty file.
+	const sourceMarkdown = usableMarkdown ?? (cv ? jsonToMarkdown(cv) : "");
+	const plainText = markdownToPlainText(sourceMarkdown);
 	return new NextResponse(plainText, {
 		headers: {
 			"Content-Type": "text/plain; charset=utf-8",
 			"Content-Disposition": `attachment; filename="${baseName}.txt"`,
 		},
 	});
+}
+
+function isUsableMarkdown(value: string | null | undefined): value is string {
+	if (!value) return false;
+	const trimmed = value.trim();
+	if (!trimmed) return false;
+	return !looksLikeHtml(trimmed);
 }
 
 // Prefer the structured JSON when present; fall back to parsing the edited

--- a/src/app/api/applications/[id]/export/route.ts
+++ b/src/app/api/applications/[id]/export/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/lib/auth";
 import { TailoredCvSchema } from "@/lib/cv-schema";
 import { jsonToMarkdown, looksLikeHtml, markdownToJson } from "@/lib/cv-serializer";
 import { generateCvDocx, generateDocx, markdownToPlainText } from "@/lib/export";
+import { htmlToMarkdown } from "@/lib/html-to-markdown";
 import { prisma } from "@/lib/prisma";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -27,16 +28,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 	const rawContent = isCoverLetter
 		? application.coverLetter
 		: (application.tailoredCVEdited ?? application.tailoredCV);
-	// Cover letters are saved as Tiptap HTML (no JSON fallback exists), so
-	// HTML must pass through. CVs additionally have a structured-JSON path
-	// — for them, treat HTML / whitespace-only markdown as "no markdown" so
-	// the route never falls back to a renderer that would emit raw tags.
-	const hasContent = Boolean(rawContent?.trim());
-	const usableCvMarkdown = !isCoverLetter && isUsableMarkdown(rawContent) ? rawContent : null;
-	const cv = isCoverLetter ? null : resolveTailoredCv(application.tailoredCvJson, usableCvMarkdown);
+	// Tiptap saves edits as HTML (via `editor.getHTML()`); normalize to markdown
+	// up-front so neither downstream renderer ever sees raw tags. Empty input
+	// resolves to null and the route returns 400 below.
+	const markdown = normalizeContent(rawContent);
+	const cv = isCoverLetter ? null : resolveTailoredCv(application.tailoredCvJson, markdown);
 
-	const canExport = isCoverLetter ? hasContent : Boolean(usableCvMarkdown || cv);
-	if (!canExport) {
+	if (!markdown && !cv) {
 		return NextResponse.json(
 			{ error: `No ${isCoverLetter ? "cover letter" : "tailored CV"} to export` },
 			{ status: 400 },
@@ -50,13 +48,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 	if (format === "docx") {
 		let buffer: Buffer;
 		if (isCoverLetter) {
-			// Guarded above — rawContent is non-empty here.
-			buffer = await generateDocx(rawContent as string, `Cover Letter - ${application.title}`);
+			// Guarded above — markdown is non-null here.
+			buffer = await generateDocx(markdown as string, `Cover Letter - ${application.title}`);
 		} else if (cv) {
 			buffer = await generateCvDocx(cv, `${application.title} - Tailored CV`);
 		} else {
-			// Last resort: validated non-HTML markdown CV with no parseable JSON.
-			buffer = await generateDocx(usableCvMarkdown as string, `${application.title} - Tailored CV`);
+			// CV with no parseable JSON — render the normalized markdown.
+			buffer = await generateDocx(markdown as string, `${application.title} - Tailored CV`);
 		}
 
 		return new NextResponse(new Uint8Array(buffer), {
@@ -67,13 +65,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 		});
 	}
 
-	// Plain text fallback (for PDF, client will handle rendering). When the CV
-	// row has only structured JSON (no edited markdown), serialize the JSON
-	// first so the response isn't an empty file. Cover letters fall through
-	// the same plain-text path on whatever content they have.
-	const sourceMarkdown = isCoverLetter
-		? (rawContent ?? "")
-		: (usableCvMarkdown ?? (cv ? jsonToMarkdown(cv) : ""));
+	// Plain text fallback (for PDF, client renders). When the CV row has only
+	// structured JSON (no markdown), serialize the JSON first so the response
+	// isn't an empty file.
+	const sourceMarkdown = markdown ?? (cv ? jsonToMarkdown(cv) : "");
 	const plainText = markdownToPlainText(sourceMarkdown);
 	return new NextResponse(plainText, {
 		headers: {
@@ -83,15 +78,20 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 	});
 }
 
-function isUsableMarkdown(value: string | null | undefined): value is string {
-	if (!value) return false;
+// Trim, drop empty content, and convert Tiptap HTML to markdown.
+function normalizeContent(value: string | null | undefined): string | null {
+	if (!value) return null;
 	const trimmed = value.trim();
-	if (!trimmed) return false;
-	return !looksLikeHtml(trimmed);
+	if (!trimmed) return null;
+	if (looksLikeHtml(trimmed)) {
+		const converted = htmlToMarkdown(trimmed).trim();
+		return converted ? converted : null;
+	}
+	return trimmed;
 }
 
-// Prefer the structured JSON when present; fall back to parsing the edited
-// markdown so legacy applications (pre-#7) still get the styled DOCX.
+// Prefer the structured JSON when present; fall back to parsing the
+// (now-markdown) edited content so legacy applications still get the styled DOCX.
 function resolveTailoredCv(json: unknown, markdown: string | null) {
 	if (json) {
 		const parsed = TailoredCvSchema.safeParse(json);

--- a/src/app/api/applications/[id]/export/route.ts
+++ b/src/app/api/applications/[id]/export/route.ts
@@ -1,13 +1,12 @@
 import { headers } from "next/headers";
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { generateDocx, markdownToPlainText } from "@/lib/export";
+import { TailoredCvSchema } from "@/lib/cv-schema";
+import { markdownToJson } from "@/lib/cv-serializer";
+import { generateCvDocx, generateDocx, markdownToPlainText } from "@/lib/export";
 import { prisma } from "@/lib/prisma";
 
-export async function GET(
-	request: NextRequest,
-	{ params }: { params: Promise<{ id: string }> },
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
 	const session = await auth.api.getSession({ headers: await headers() });
 	if (!session) {
 		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -23,44 +22,65 @@ export async function GET(
 
 	const format = request.nextUrl.searchParams.get("format") ?? "docx";
 	const type = request.nextUrl.searchParams.get("type") ?? "cv";
+	const isCoverLetter = type === "cover-letter";
 
-	const content =
-		type === "cover-letter"
-			? application.coverLetter
-			: application.tailoredCVEdited ?? application.tailoredCV;
+	const markdown = isCoverLetter
+		? application.coverLetter
+		: (application.tailoredCVEdited ?? application.tailoredCV);
 
-	if (!content) {
+	if (!markdown && (isCoverLetter || !application.tailoredCvJson)) {
 		return NextResponse.json(
-			{ error: `No ${type === "cover-letter" ? "cover letter" : "tailored CV"} to export` },
+			{ error: `No ${isCoverLetter ? "cover letter" : "tailored CV"} to export` },
 			{ status: 400 },
 		);
 	}
 
-	const baseName = `${application.company.replace(/[^a-zA-Z0-9]/g, "-")}_${type === "cover-letter" ? "cover-letter" : "tailored-cv"}`;
+	const baseName = `${application.company.replace(/[^a-zA-Z0-9]/g, "-")}_${
+		isCoverLetter ? "cover-letter" : "tailored-cv"
+	}`;
 
 	if (format === "docx") {
-		const buffer = await generateDocx(
-			content,
-			type === "cover-letter"
-				? `Cover Letter - ${application.title}`
-				: `${application.title} - Tailored CV`,
-		);
+		let buffer: Buffer;
+		if (isCoverLetter) {
+			buffer = await generateDocx(markdown ?? "", `Cover Letter - ${application.title}`);
+		} else {
+			const cv = resolveTailoredCv(application.tailoredCvJson, markdown);
+			buffer = cv
+				? await generateCvDocx(cv, `${application.title} - Tailored CV`)
+				: await generateDocx(markdown ?? "", `${application.title} - Tailored CV`);
+		}
 
 		return new NextResponse(new Uint8Array(buffer), {
 			headers: {
-				"Content-Type":
-					"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				"Content-Type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 				"Content-Disposition": `attachment; filename="${baseName}.docx"`,
 			},
 		});
 	}
 
 	// Plain text fallback (for PDF, client will handle rendering)
-	const plainText = markdownToPlainText(content);
+	const plainText = markdownToPlainText(markdown ?? "");
 	return new NextResponse(plainText, {
 		headers: {
 			"Content-Type": "text/plain; charset=utf-8",
 			"Content-Disposition": `attachment; filename="${baseName}.txt"`,
 		},
 	});
+}
+
+// Prefer the structured JSON when present; fall back to parsing the edited
+// markdown so legacy applications (pre-#7) still get the styled DOCX.
+function resolveTailoredCv(json: unknown, markdown: string | null) {
+	if (json) {
+		const parsed = TailoredCvSchema.safeParse(json);
+		if (parsed.success) return parsed.data;
+	}
+	if (!markdown) return null;
+	try {
+		const fromMarkdown = markdownToJson(markdown);
+		const parsed = TailoredCvSchema.safeParse(fromMarkdown);
+		return parsed.success ? parsed.data : null;
+	} catch {
+		return null;
+	}
 }

--- a/src/app/api/applications/[id]/export/route.ts
+++ b/src/app/api/applications/[id]/export/route.ts
@@ -24,15 +24,19 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 	const type = request.nextUrl.searchParams.get("type") ?? "cv";
 	const isCoverLetter = type === "cover-letter";
 
-	const rawMarkdown = isCoverLetter
+	const rawContent = isCoverLetter
 		? application.coverLetter
 		: (application.tailoredCVEdited ?? application.tailoredCV);
-	// Treat HTML- or whitespace-only content as "no markdown" so the route never
-	// falls back to a renderer that would emit raw tags or a blank file.
-	const usableMarkdown = isUsableMarkdown(rawMarkdown) ? rawMarkdown : null;
-	const cv = isCoverLetter ? null : resolveTailoredCv(application.tailoredCvJson, usableMarkdown);
+	// Cover letters are saved as Tiptap HTML (no JSON fallback exists), so
+	// HTML must pass through. CVs additionally have a structured-JSON path
+	// — for them, treat HTML / whitespace-only markdown as "no markdown" so
+	// the route never falls back to a renderer that would emit raw tags.
+	const hasContent = Boolean(rawContent?.trim());
+	const usableCvMarkdown = !isCoverLetter && isUsableMarkdown(rawContent) ? rawContent : null;
+	const cv = isCoverLetter ? null : resolveTailoredCv(application.tailoredCvJson, usableCvMarkdown);
 
-	if (!usableMarkdown && !cv) {
+	const canExport = isCoverLetter ? hasContent : Boolean(usableCvMarkdown || cv);
+	if (!canExport) {
 		return NextResponse.json(
 			{ error: `No ${isCoverLetter ? "cover letter" : "tailored CV"} to export` },
 			{ status: 400 },
@@ -46,13 +50,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 	if (format === "docx") {
 		let buffer: Buffer;
 		if (isCoverLetter) {
-			// Guarded above — usableMarkdown is non-null here.
-			buffer = await generateDocx(usableMarkdown as string, `Cover Letter - ${application.title}`);
+			// Guarded above — rawContent is non-empty here.
+			buffer = await generateDocx(rawContent as string, `Cover Letter - ${application.title}`);
 		} else if (cv) {
 			buffer = await generateCvDocx(cv, `${application.title} - Tailored CV`);
 		} else {
 			// Last resort: validated non-HTML markdown CV with no parseable JSON.
-			buffer = await generateDocx(usableMarkdown as string, `${application.title} - Tailored CV`);
+			buffer = await generateDocx(usableCvMarkdown as string, `${application.title} - Tailored CV`);
 		}
 
 		return new NextResponse(new Uint8Array(buffer), {
@@ -63,10 +67,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 		});
 	}
 
-	// Plain text fallback (for PDF, client will handle rendering). When the row
-	// has only structured JSON (no edited markdown), serialize the JSON first so
-	// the response isn't an empty file.
-	const sourceMarkdown = usableMarkdown ?? (cv ? jsonToMarkdown(cv) : "");
+	// Plain text fallback (for PDF, client will handle rendering). When the CV
+	// row has only structured JSON (no edited markdown), serialize the JSON
+	// first so the response isn't an empty file. Cover letters fall through
+	// the same plain-text path on whatever content they have.
+	const sourceMarkdown = isCoverLetter
+		? (rawContent ?? "")
+		: (usableCvMarkdown ?? (cv ? jsonToMarkdown(cv) : ""));
 	const plainText = markdownToPlainText(sourceMarkdown);
 	return new NextResponse(plainText, {
 		headers: {

--- a/src/lib/cv-styles.ts
+++ b/src/lib/cv-styles.ts
@@ -1,0 +1,45 @@
+// Shared style tokens consumed by DOCX (Step 4) and PDF (Step 5) renderers.
+// Single source of truth so the two exports stay visually in sync.
+
+export const CV_STYLES = {
+	font: "Calibri",
+	fontSize: {
+		body: 11,
+		h1: 18,
+		h2: 13,
+		h3: 11.5,
+		contact: 10,
+	},
+	color: {
+		text: "222222",
+		heading: "111111",
+		muted: "555555",
+		accent: "1A56DB",
+	},
+	// Inches.
+	margin: {
+		top: 0.75,
+		right: 0.75,
+		bottom: 0.75,
+		left: 0.75,
+	},
+	lineHeight: 1.15,
+	// Points.
+	spacing: {
+		sectionBefore: 8,
+		sectionAfter: 4,
+		bulletAfter: 2,
+	},
+} as const;
+
+// ─── DOCX unit conversions ─────────────────────────────────────────────
+// docx uses half-points for font size, twentieths-of-a-point for spacing,
+// and twips (1440 per inch) for margins.
+
+export const inchesToTwips = (inches: number): number => Math.round(inches * 1440);
+export const ptToHalfPt = (pt: number): number => Math.round(pt * 2);
+export const ptToTwips = (pt: number): number => Math.round(pt * 20);
+
+// 1.15 line spacing in twentieths-of-a-point relative to body size.
+export const docxLineSpacing = (lineHeight: number, bodyPt: number): number =>
+	Math.round(lineHeight * bodyPt * 20);

--- a/src/lib/export.test.ts
+++ b/src/lib/export.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { TailoredCv } from "@/lib/cv-schema";
+import { generateCvDocx, generateDocx } from "@/lib/export";
+
+const sampleCv: TailoredCv = {
+	header: {
+		name: "Jane Doe",
+		title: "Senior Software Engineer",
+		email: "jane@example.com",
+		phone: "+1 555 0100",
+		location: "Remote",
+		links: [{ url: "https://github.com/janedoe", label: "GitHub" }, { url: "https://janedoe.dev" }],
+	},
+	summary: "Engineer with **10 years** of full-stack experience.",
+	skills: [
+		{ category: "Languages", items: ["TypeScript", "Go", "Python"] },
+		{ category: "Cloud", items: ["AWS", "GCP"] },
+	],
+	experience: [
+		{
+			company: "Acme Corp",
+			role: "Staff Engineer",
+			location: "Remote",
+			start: "2022",
+			end: "Present",
+			bullets: [
+				"Led migration to **TypeScript** across 8 services.",
+				"Cut p95 latency by *40%* via caching.",
+			],
+		},
+	],
+	education: [
+		{
+			school: "State University",
+			degree: "B.S. Computer Science",
+			start: "2010",
+			end: "2014",
+		},
+	],
+	projects: [
+		{
+			name: "Side Project",
+			url: "https://example.com/proj",
+			description: "Open-source CLI for X.",
+			bullets: ["Reached 1k GitHub stars."],
+		},
+	],
+	certifications: [{ name: "AWS Solutions Architect", issuer: "AWS", date: "2023" }],
+};
+
+// DOCX is a zip; the PK header signals a non-empty, structurally valid bundle.
+const isDocxBuffer = (buf: Buffer) => buf.length > 1000 && buf[0] === 0x50 && buf[1] === 0x4b;
+
+describe("generateCvDocx", () => {
+	it("renders a TailoredCv into a DOCX buffer", async () => {
+		const buf = await generateCvDocx(sampleCv, "Sample - Tailored CV");
+		expect(isDocxBuffer(buf)).toBe(true);
+	});
+
+	it("renders when optional sections are empty", async () => {
+		const buf = await generateCvDocx({
+			header: { name: "Minimal Person", links: [] },
+			summary: "",
+			skills: [],
+			experience: [],
+			education: [],
+			projects: [],
+			certifications: [],
+		});
+		expect(isDocxBuffer(buf)).toBe(true);
+	});
+});
+
+describe("generateDocx (markdown / cover letter)", () => {
+	it("renders markdown into a DOCX buffer", async () => {
+		const buf = await generateDocx(
+			"# Cover Letter\n\nDear Hiring Manager,\n\n- Point one\n- Point **two**\n\nThanks.",
+			"Cover Letter",
+		);
+		expect(isDocxBuffer(buf)).toBe(true);
+	});
+});

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,114 +1,551 @@
 import {
+	AlignmentType,
+	BorderStyle,
 	Document,
+	ExternalHyperlink,
 	HeadingLevel,
 	Packer,
 	Paragraph,
+	type ParagraphChild,
+	TabStopType,
 	TextRun,
-	AlignmentType,
+	UnderlineType,
 } from "docx";
+import type {
+	TailoredCv,
+	TailoredCvCertification,
+	TailoredCvEducation,
+	TailoredCvExperience,
+	TailoredCvHeader,
+	TailoredCvProject,
+	TailoredCvSkillGroup,
+} from "@/lib/cv-schema";
+import { CV_STYLES, docxLineSpacing, inchesToTwips, ptToHalfPt, ptToTwips } from "@/lib/cv-styles";
+import { parseInlineEmphasis } from "@/lib/inline-emphasis";
 
-// ─── Markdown → Structured Blocks ───────────────────────────────────
+// ─── Shared docx primitives ─────────────────────────────────────────────
 
-interface Block {
+const FONT = CV_STYLES.font;
+const BODY_HALF = ptToHalfPt(CV_STYLES.fontSize.body);
+const CONTACT_HALF = ptToHalfPt(CV_STYLES.fontSize.contact);
+const H1_HALF = ptToHalfPt(CV_STYLES.fontSize.h1);
+const H2_HALF = ptToHalfPt(CV_STYLES.fontSize.h2);
+const H3_HALF = ptToHalfPt(CV_STYLES.fontSize.h3);
+const LINE = docxLineSpacing(CV_STYLES.lineHeight, CV_STYLES.fontSize.body);
+// US Letter (8.5") minus left+right margins gives the printable width used as
+// the right tab-stop for date alignment.
+const RIGHT_TAB = inchesToTwips(8.5 - CV_STYLES.margin.left - CV_STYLES.margin.right);
+
+function emphasisRuns(
+	text: string,
+	opts: { bold?: boolean; italics?: boolean; color?: string; size?: number } = {},
+): TextRun[] {
+	return parseInlineEmphasis(text).map(
+		(t) =>
+			new TextRun({
+				text: t.text,
+				bold: opts.bold || t.bold,
+				italics: opts.italics || t.italic,
+				color: opts.color ?? CV_STYLES.color.text,
+				font: FONT,
+				size: opts.size ?? BODY_HALF,
+			}),
+	);
+}
+
+function hyperlinkRun(text: string, url: string, size = BODY_HALF): ExternalHyperlink {
+	return new ExternalHyperlink({
+		link: url,
+		children: [
+			new TextRun({
+				text,
+				font: FONT,
+				size,
+				color: CV_STYLES.color.accent,
+				underline: { type: UnderlineType.SINGLE, color: CV_STYLES.color.accent },
+			}),
+		],
+	});
+}
+
+// ─── CV (TailoredCv → DOCX) ─────────────────────────────────────────────
+
+function nameHeading(name: string): Paragraph {
+	return new Paragraph({
+		alignment: AlignmentType.CENTER,
+		spacing: { after: ptToTwips(CV_STYLES.spacing.sectionAfter) },
+		children: [
+			new TextRun({
+				text: name,
+				bold: true,
+				color: CV_STYLES.color.heading,
+				font: FONT,
+				size: H1_HALF,
+			}),
+		],
+	});
+}
+
+function plainContactRun(text: string): TextRun {
+	return new TextRun({
+		text,
+		font: FONT,
+		size: CONTACT_HALF,
+		color: CV_STYLES.color.text,
+	});
+}
+
+function contactSeparator(): TextRun {
+	return new TextRun({
+		text: "  •  ",
+		font: FONT,
+		size: CONTACT_HALF,
+		color: CV_STYLES.color.muted,
+	});
+}
+
+function contactLine(header: TailoredCvHeader): Paragraph | null {
+	const parts: ParagraphChild[] = [];
+	const push = (child: ParagraphChild) => {
+		if (parts.length > 0) parts.push(contactSeparator());
+		parts.push(child);
+	};
+
+	if (header.title) {
+		push(
+			new TextRun({
+				text: header.title,
+				italics: true,
+				font: FONT,
+				size: CONTACT_HALF,
+				color: CV_STYLES.color.muted,
+			}),
+		);
+	}
+	if (header.email) push(hyperlinkRun(header.email, `mailto:${header.email}`, CONTACT_HALF));
+	if (header.phone) push(plainContactRun(header.phone));
+	if (header.location) push(plainContactRun(header.location));
+	for (const link of header.links) {
+		push(hyperlinkRun(link.label ?? link.url, link.url, CONTACT_HALF));
+	}
+
+	if (parts.length === 0) return null;
+	return new Paragraph({
+		alignment: AlignmentType.CENTER,
+		spacing: { after: ptToTwips(CV_STYLES.spacing.sectionAfter) },
+		children: parts,
+	});
+}
+
+function sectionHeading(text: string): Paragraph {
+	return new Paragraph({
+		keepNext: true,
+		spacing: {
+			before: ptToTwips(CV_STYLES.spacing.sectionBefore),
+			after: ptToTwips(CV_STYLES.spacing.sectionAfter),
+		},
+		border: {
+			bottom: {
+				style: BorderStyle.SINGLE,
+				size: 6,
+				color: CV_STYLES.color.heading,
+				space: 1,
+			},
+		},
+		children: [
+			new TextRun({
+				text: text.toUpperCase(),
+				bold: true,
+				color: CV_STYLES.color.heading,
+				font: FONT,
+				size: H2_HALF,
+			}),
+		],
+	});
+}
+
+function summaryParagraph(summary: string): Paragraph {
+	return new Paragraph({
+		spacing: { after: ptToTwips(CV_STYLES.spacing.sectionAfter), line: LINE },
+		children: emphasisRuns(summary.trim()),
+	});
+}
+
+function skillParagraph(group: TailoredCvSkillGroup): Paragraph {
+	return new Paragraph({
+		spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
+		children: [
+			new TextRun({
+				text: `${group.category}: `,
+				bold: true,
+				font: FONT,
+				size: BODY_HALF,
+				color: CV_STYLES.color.heading,
+			}),
+			new TextRun({
+				text: group.items.join(", "),
+				font: FONT,
+				size: BODY_HALF,
+				color: CV_STYLES.color.text,
+			}),
+		],
+	});
+}
+
+function formatDateRange(start?: string, end?: string): string {
+	const s = start?.trim();
+	const e = end?.trim();
+	if (s && e) return `${s} – ${e}`;
+	if (s) return `${s} – Present`;
+	if (e) return e;
+	return "";
+}
+
+function experienceParagraphs(job: TailoredCvExperience): Paragraph[] {
+	const paragraphs: Paragraph[] = [];
+	const dateRange = formatDateRange(job.start, job.end);
+	const meta = [job.location, dateRange].filter(Boolean).join(" • ");
+
+	const headerChildren: ParagraphChild[] = [
+		new TextRun({
+			text: job.company,
+			bold: true,
+			font: FONT,
+			size: H3_HALF,
+			color: CV_STYLES.color.heading,
+		}),
+	];
+	if (job.role) {
+		headerChildren.push(
+			new TextRun({
+				text: "  —  ",
+				font: FONT,
+				size: H3_HALF,
+				color: CV_STYLES.color.muted,
+			}),
+			new TextRun({
+				text: job.role,
+				italics: true,
+				font: FONT,
+				size: H3_HALF,
+				color: CV_STYLES.color.text,
+			}),
+		);
+	}
+	if (meta) {
+		headerChildren.push(
+			new TextRun({ text: "\t", font: FONT }),
+			new TextRun({
+				text: meta,
+				font: FONT,
+				size: BODY_HALF,
+				color: CV_STYLES.color.muted,
+			}),
+		);
+	}
+
+	paragraphs.push(
+		new Paragraph({
+			keepNext: true,
+			spacing: { before: ptToTwips(4), after: ptToTwips(2), line: LINE },
+			tabStops: meta ? [{ type: TabStopType.RIGHT, position: RIGHT_TAB }] : undefined,
+			children: headerChildren,
+		}),
+	);
+
+	for (const bullet of job.bullets) {
+		paragraphs.push(
+			new Paragraph({
+				bullet: { level: 0 },
+				indent: { left: inchesToTwips(0.25), hanging: inchesToTwips(0.15) },
+				spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
+				children: emphasisRuns(bullet),
+			}),
+		);
+	}
+	return paragraphs;
+}
+
+function educationParagraphs(edu: TailoredCvEducation): Paragraph[] {
+	const dateRange = formatDateRange(edu.start, edu.end);
+	const headerChildren: ParagraphChild[] = [
+		new TextRun({
+			text: edu.school,
+			bold: true,
+			font: FONT,
+			size: H3_HALF,
+			color: CV_STYLES.color.heading,
+		}),
+	];
+	if (edu.degree) {
+		headerChildren.push(
+			new TextRun({
+				text: ` — ${edu.degree}`,
+				font: FONT,
+				size: H3_HALF,
+				color: CV_STYLES.color.text,
+			}),
+		);
+	}
+	if (dateRange) {
+		headerChildren.push(
+			new TextRun({ text: "\t", font: FONT }),
+			new TextRun({
+				text: dateRange,
+				font: FONT,
+				size: BODY_HALF,
+				color: CV_STYLES.color.muted,
+			}),
+		);
+	}
+
+	const paragraphs: Paragraph[] = [
+		new Paragraph({
+			keepNext: Boolean(edu.details),
+			spacing: { before: ptToTwips(4), after: ptToTwips(2), line: LINE },
+			tabStops: dateRange ? [{ type: TabStopType.RIGHT, position: RIGHT_TAB }] : undefined,
+			children: headerChildren,
+		}),
+	];
+	if (edu.details) {
+		paragraphs.push(
+			new Paragraph({
+				spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
+				children: emphasisRuns(edu.details),
+			}),
+		);
+	}
+	return paragraphs;
+}
+
+function projectParagraphs(project: TailoredCvProject): Paragraph[] {
+	const headerChildren: ParagraphChild[] = [
+		new TextRun({
+			text: project.name,
+			bold: true,
+			font: FONT,
+			size: H3_HALF,
+			color: CV_STYLES.color.heading,
+		}),
+	];
+	if (project.url) {
+		headerChildren.push(
+			new TextRun({ text: "  ", font: FONT }),
+			hyperlinkRun(project.url, project.url, BODY_HALF),
+		);
+	}
+	const paragraphs: Paragraph[] = [
+		new Paragraph({
+			keepNext: true,
+			spacing: { before: ptToTwips(4), after: ptToTwips(2), line: LINE },
+			children: headerChildren,
+		}),
+	];
+	if (project.description) {
+		paragraphs.push(
+			new Paragraph({
+				spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
+				children: emphasisRuns(project.description),
+			}),
+		);
+	}
+	for (const bullet of project.bullets) {
+		paragraphs.push(
+			new Paragraph({
+				bullet: { level: 0 },
+				indent: { left: inchesToTwips(0.25), hanging: inchesToTwips(0.15) },
+				spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
+				children: emphasisRuns(bullet),
+			}),
+		);
+	}
+	return paragraphs;
+}
+
+function certificationParagraph(cert: TailoredCvCertification): Paragraph {
+	const meta = [cert.issuer, cert.date].filter(Boolean).join(" • ");
+	const children: ParagraphChild[] = [
+		new TextRun({
+			text: cert.name,
+			bold: true,
+			font: FONT,
+			size: BODY_HALF,
+			color: CV_STYLES.color.heading,
+		}),
+	];
+	if (meta) {
+		children.push(
+			new TextRun({ text: "\t", font: FONT }),
+			new TextRun({
+				text: meta,
+				font: FONT,
+				size: BODY_HALF,
+				color: CV_STYLES.color.muted,
+			}),
+		);
+	}
+	return new Paragraph({
+		spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
+		tabStops: meta ? [{ type: TabStopType.RIGHT, position: RIGHT_TAB }] : undefined,
+		children,
+	});
+}
+
+function buildCvParagraphs(cv: TailoredCv): Paragraph[] {
+	const paragraphs: Paragraph[] = [nameHeading(cv.header.name)];
+	const contact = contactLine(cv.header);
+	if (contact) paragraphs.push(contact);
+
+	if (cv.summary?.trim()) {
+		paragraphs.push(sectionHeading("Summary"), summaryParagraph(cv.summary));
+	}
+	if (cv.skills.length > 0) {
+		paragraphs.push(sectionHeading("Skills"));
+		for (const group of cv.skills) paragraphs.push(skillParagraph(group));
+	}
+	if (cv.experience.length > 0) {
+		paragraphs.push(sectionHeading("Experience"));
+		for (const job of cv.experience) paragraphs.push(...experienceParagraphs(job));
+	}
+	if (cv.projects.length > 0) {
+		paragraphs.push(sectionHeading("Projects"));
+		for (const project of cv.projects) paragraphs.push(...projectParagraphs(project));
+	}
+	if (cv.education.length > 0) {
+		paragraphs.push(sectionHeading("Education"));
+		for (const edu of cv.education) paragraphs.push(...educationParagraphs(edu));
+	}
+	if (cv.certifications.length > 0) {
+		paragraphs.push(sectionHeading("Certifications"));
+		for (const cert of cv.certifications) paragraphs.push(certificationParagraph(cert));
+	}
+	return paragraphs;
+}
+
+function buildDocument(paragraphs: Paragraph[], title?: string): Document {
+	return new Document({
+		title: title ?? "Document",
+		styles: {
+			default: {
+				document: {
+					run: { font: FONT, size: BODY_HALF, color: CV_STYLES.color.text },
+					paragraph: { spacing: { line: LINE } },
+				},
+			},
+		},
+		sections: [
+			{
+				properties: {
+					page: {
+						margin: {
+							top: inchesToTwips(CV_STYLES.margin.top),
+							right: inchesToTwips(CV_STYLES.margin.right),
+							bottom: inchesToTwips(CV_STYLES.margin.bottom),
+							left: inchesToTwips(CV_STYLES.margin.left),
+						},
+					},
+				},
+				children: paragraphs,
+			},
+		],
+	});
+}
+
+export async function generateCvDocx(cv: TailoredCv, title?: string): Promise<Buffer> {
+	const doc = buildDocument(buildCvParagraphs(cv), title);
+	return Buffer.from(await Packer.toBuffer(doc));
+}
+
+// ─── Markdown DOCX (cover letters) ──────────────────────────────────────
+
+interface MarkdownBlock {
 	type: "heading" | "paragraph" | "bullet" | "ordered";
 	level?: number;
 	text: string;
 }
 
-function parseMarkdownToBlocks(markdown: string): Block[] {
-	const lines = markdown.split("\n");
-	const blocks: Block[] = [];
+function parseMarkdownToBlocks(markdown: string): MarkdownBlock[] {
+	const blocks: MarkdownBlock[] = [];
+	for (const raw of markdown.split("\n")) {
+		const line = raw.trim();
+		if (!line) continue;
 
-	for (const line of lines) {
-		const trimmed = line.trim();
-		if (!trimmed) continue;
-
-		// Headings
-		const headingMatch = trimmed.match(/^(#{1,3})\s+(.+)/);
-		if (headingMatch) {
-			blocks.push({
-				type: "heading",
-				level: headingMatch[1].length,
-				text: headingMatch[2],
-			});
+		const heading = line.match(/^(#{1,3})\s+(.+)/);
+		if (heading) {
+			blocks.push({ type: "heading", level: heading[1].length, text: heading[2] });
 			continue;
 		}
-
-		// Bullet list
-		if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
-			blocks.push({ type: "bullet", text: trimmed.slice(2) });
+		if (line.startsWith("- ") || line.startsWith("* ")) {
+			blocks.push({ type: "bullet", text: line.slice(2) });
 			continue;
 		}
-
-		// Ordered list
-		const orderedMatch = trimmed.match(/^\d+\.\s+(.+)/);
-		if (orderedMatch) {
-			blocks.push({ type: "ordered", text: orderedMatch[1] });
+		const ordered = line.match(/^\d+\.\s+(.+)/);
+		if (ordered) {
+			blocks.push({ type: "ordered", text: ordered[1] });
 			continue;
 		}
-
-		// Regular paragraph
-		blocks.push({ type: "paragraph", text: trimmed });
+		blocks.push({ type: "paragraph", text: line });
 	}
-
 	return blocks;
 }
 
-function stripMarkdownFormatting(text: string): string {
-	return text
-		.replace(/\*\*(.+?)\*\*/g, "$1")
-		.replace(/\*(.+?)\*/g, "$1")
-		.replace(/__(.+?)__/g, "$1")
-		.replace(/_(.+?)_/g, "$1");
-}
-
-// ─── DOCX Export ─────────────────────────────────────────────────────
-
 export async function generateDocx(content: string, title?: string): Promise<Buffer> {
-	const blocks = parseMarkdownToBlocks(content);
 	const paragraphs: Paragraph[] = [];
-
-	for (const block of blocks) {
-		const cleanText = stripMarkdownFormatting(block.text);
-
+	for (const block of parseMarkdownToBlocks(content)) {
 		switch (block.type) {
-			case "heading":
+			case "heading": {
+				const level = block.level ?? 2;
+				const size = level === 1 ? H1_HALF : level === 2 ? H2_HALF : H3_HALF;
 				paragraphs.push(
 					new Paragraph({
-						text: cleanText,
 						heading:
-							block.level === 1
+							level === 1
 								? HeadingLevel.HEADING_1
-								: block.level === 2
+								: level === 2
 									? HeadingLevel.HEADING_2
 									: HeadingLevel.HEADING_3,
-						spacing: { before: 240, after: 120 },
+						keepNext: true,
+						spacing: {
+							before: ptToTwips(CV_STYLES.spacing.sectionBefore),
+							after: ptToTwips(CV_STYLES.spacing.sectionAfter),
+						},
+						children: [
+							new TextRun({
+								text: block.text,
+								bold: true,
+								font: FONT,
+								size,
+								color: CV_STYLES.color.heading,
+							}),
+						],
 					}),
 				);
 				break;
+			}
 			case "bullet":
 				paragraphs.push(
 					new Paragraph({
-						children: [new TextRun({ text: cleanText, size: 22 })],
 						bullet: { level: 0 },
-						spacing: { before: 60, after: 60 },
+						indent: { left: inchesToTwips(0.25), hanging: inchesToTwips(0.15) },
+						spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
+						children: emphasisRuns(block.text),
 					}),
 				);
 				break;
 			case "ordered":
 				paragraphs.push(
 					new Paragraph({
-						children: [new TextRun({ text: cleanText, size: 22 })],
 						numbering: { reference: "default-numbering", level: 0 },
-						spacing: { before: 60, after: 60 },
+						spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
+						children: emphasisRuns(block.text),
 					}),
 				);
 				break;
 			default:
 				paragraphs.push(
 					new Paragraph({
-						children: [new TextRun({ text: cleanText, size: 22 })],
-						spacing: { before: 60, after: 60 },
+						spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
+						children: emphasisRuns(block.text),
 					}),
 				);
 		}
@@ -116,6 +553,14 @@ export async function generateDocx(content: string, title?: string): Promise<Buf
 
 	const doc = new Document({
 		title: title ?? "Document",
+		styles: {
+			default: {
+				document: {
+					run: { font: FONT, size: BODY_HALF, color: CV_STYLES.color.text },
+					paragraph: { spacing: { line: LINE } },
+				},
+			},
+		},
 		numbering: {
 			config: [
 				{
@@ -136,10 +581,10 @@ export async function generateDocx(content: string, title?: string): Promise<Buf
 				properties: {
 					page: {
 						margin: {
-							top: 1440,
-							right: 1440,
-							bottom: 1440,
-							left: 1440,
+							top: inchesToTwips(CV_STYLES.margin.top),
+							right: inchesToTwips(CV_STYLES.margin.right),
+							bottom: inchesToTwips(CV_STYLES.margin.bottom),
+							left: inchesToTwips(CV_STYLES.margin.left),
 						},
 					},
 				},

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -72,6 +72,7 @@ function hyperlinkRun(text: string, url: string, size = BODY_HALF): ExternalHype
 
 function nameHeading(name: string): Paragraph {
 	return new Paragraph({
+		heading: HeadingLevel.HEADING_1,
 		alignment: AlignmentType.CENTER,
 		spacing: { after: ptToTwips(CV_STYLES.spacing.sectionAfter) },
 		children: [
@@ -139,6 +140,7 @@ function contactLine(header: TailoredCvHeader): Paragraph | null {
 
 function sectionHeading(text: string): Paragraph {
 	return new Paragraph({
+		heading: HeadingLevel.HEADING_2,
 		keepNext: true,
 		spacing: {
 			before: ptToTwips(CV_STYLES.spacing.sectionBefore),
@@ -192,7 +194,20 @@ function skillParagraph(group: TailoredCvSkillGroup): Paragraph {
 	});
 }
 
+// Generic range — no "Present" assumption. Used for education / certifications
+// where a missing end date doesn't imply ongoing.
 function formatDateRange(start?: string, end?: string): string {
+	const s = start?.trim();
+	const e = end?.trim();
+	if (s && e) return `${s} – ${e}`;
+	if (s) return s;
+	if (e) return e;
+	return "";
+}
+
+// Experience-only — a missing end date means the role is current, so render
+// "Present" as the right-hand bound.
+function formatExperienceDateRange(start?: string, end?: string): string {
 	const s = start?.trim();
 	const e = end?.trim();
 	if (s && e) return `${s} – ${e}`;
@@ -203,7 +218,7 @@ function formatDateRange(start?: string, end?: string): string {
 
 function experienceParagraphs(job: TailoredCvExperience): Paragraph[] {
 	const paragraphs: Paragraph[] = [];
-	const dateRange = formatDateRange(job.start, job.end);
+	const dateRange = formatExperienceDateRange(job.start, job.end);
 	const meta = [job.location, dateRange].filter(Boolean).join(" • ");
 
 	const headerChildren: ParagraphChild[] = [
@@ -257,7 +272,7 @@ function experienceParagraphs(job: TailoredCvExperience): Paragraph[] {
 		paragraphs.push(
 			new Paragraph({
 				bullet: { level: 0 },
-				indent: { left: inchesToTwips(0.25), hanging: inchesToTwips(0.15) },
+				indent: { left: inchesToTwips(0.25), hanging: inchesToTwips(0.25) },
 				spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
 				children: emphasisRuns(bullet),
 			}),
@@ -353,7 +368,7 @@ function projectParagraphs(project: TailoredCvProject): Paragraph[] {
 		paragraphs.push(
 			new Paragraph({
 				bullet: { level: 0 },
-				indent: { left: inchesToTwips(0.25), hanging: inchesToTwips(0.15) },
+				indent: { left: inchesToTwips(0.25), hanging: inchesToTwips(0.25) },
 				spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
 				children: emphasisRuns(bullet),
 			}),
@@ -526,7 +541,7 @@ export async function generateDocx(content: string, title?: string): Promise<Buf
 				paragraphs.push(
 					new Paragraph({
 						bullet: { level: 0 },
-						indent: { left: inchesToTwips(0.25), hanging: inchesToTwips(0.15) },
+						indent: { left: inchesToTwips(0.25), hanging: inchesToTwips(0.25) },
 						spacing: { after: ptToTwips(CV_STYLES.spacing.bulletAfter), line: LINE },
 						children: emphasisRuns(block.text),
 					}),

--- a/src/lib/html-to-markdown.test.ts
+++ b/src/lib/html-to-markdown.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { htmlToMarkdown } from "@/lib/html-to-markdown";
+
+describe("htmlToMarkdown", () => {
+	it("converts Tiptap paragraphs", () => {
+		expect(htmlToMarkdown("<p>Hello world</p><p>Second line</p>")).toBe(
+			"Hello world\n\nSecond line",
+		);
+	});
+
+	it("converts headings", () => {
+		expect(htmlToMarkdown("<h1>Name</h1><h2>Section</h2>")).toBe("# Name\n\n## Section");
+	});
+
+	it("converts inline emphasis", () => {
+		expect(htmlToMarkdown("<p>Built <strong>scalable</strong> <em>APIs</em></p>")).toBe(
+			"Built **scalable** *APIs*",
+		);
+	});
+
+	it("converts unordered and ordered lists", () => {
+		expect(htmlToMarkdown("<ul><li>One</li><li>Two</li></ul><ol><li>A</li><li>B</li></ol>")).toBe(
+			"- One\n- Two\n\n- A\n- B",
+		);
+	});
+
+	it("converts anchors with href", () => {
+		expect(htmlToMarkdown('<p>Visit <a href="https://example.com">our site</a></p>')).toBe(
+			"Visit [our site](https://example.com)",
+		);
+	});
+
+	it("decodes common entities", () => {
+		expect(htmlToMarkdown("<p>R&amp;D &nbsp;rocks</p>")).toBe("R&D  rocks");
+	});
+
+	it("preserves <br> as a newline", () => {
+		expect(htmlToMarkdown("<p>Line 1<br />Line 2</p>")).toBe("Line 1\nLine 2");
+	});
+
+	it("returns empty for empty/whitespace HTML", () => {
+		expect(htmlToMarkdown("")).toBe("");
+		expect(htmlToMarkdown("<p></p>")).toBe("");
+	});
+});

--- a/src/lib/html-to-markdown.ts
+++ b/src/lib/html-to-markdown.ts
@@ -1,0 +1,55 @@
+// Convert Tiptap-style HTML (the output of TiptapEditor.editor.getHTML()) to
+// markdown that the rest of the export pipeline understands. Tiptap emits a
+// well-formed, narrow subset of HTML — paragraphs, headings, lists, inline
+// emphasis, line breaks, anchors — which makes a regex-based converter
+// tractable without pulling in a DOM parser. Content is treated as untrusted
+// markdown after conversion; downstream renderers do not interpret HTML.
+
+const ENTITIES: Record<string, string> = {
+	"&nbsp;": " ",
+	"&amp;": "&",
+	"&lt;": "<",
+	"&gt;": ">",
+	"&quot;": '"',
+	"&#39;": "'",
+	"&apos;": "'",
+};
+
+export function htmlToMarkdown(html: string): string {
+	let s = html.replace(/\r\n?/g, "\n");
+
+	// Headings before paragraphs so we don't strip their wrapping tags first.
+	s = s.replace(/<\s*h1\b[^>]*>([\s\S]*?)<\s*\/h1\s*>/gi, "\n# $1\n\n");
+	s = s.replace(/<\s*h2\b[^>]*>([\s\S]*?)<\s*\/h2\s*>/gi, "\n## $1\n\n");
+	s = s.replace(/<\s*h3\b[^>]*>([\s\S]*?)<\s*\/h3\s*>/gi, "\n### $1\n\n");
+	s = s.replace(/<\s*h[4-6]\b[^>]*>([\s\S]*?)<\s*\/h[4-6]\s*>/gi, "\n#### $1\n\n");
+
+	// Block-level breaks.
+	s = s
+		.replace(/<\s*br\s*\/?\s*>/gi, "\n")
+		.replace(/<\s*\/p\s*>/gi, "\n\n")
+		.replace(/<\s*\/div\s*>/gi, "\n\n")
+		.replace(/<\s*p\b[^>]*>/gi, "")
+		.replace(/<\s*div\b[^>]*>/gi, "");
+
+	// Lists — treat ordered and unordered identically (downstream re-numbers).
+	s = s.replace(/<\s*li\b[^>]*>([\s\S]*?)<\s*\/li\s*>/gi, "- $1\n");
+	s = s.replace(/<\s*\/?(?:ul|ol)\b[^>]*>/gi, "\n");
+
+	// Inline emphasis.
+	s = s.replace(/<\s*(?:strong|b)\b[^>]*>([\s\S]*?)<\s*\/(?:strong|b)\s*>/gi, "**$1**");
+	s = s.replace(/<\s*(?:em|i)\b[^>]*>([\s\S]*?)<\s*\/(?:em|i)\s*>/gi, "*$1*");
+
+	// Anchors — preserve href as a markdown link.
+	s = s.replace(/<\s*a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\s*\/a\s*>/gi, "[$2]($1)");
+
+	// Strip any remaining tags.
+	s = s.replace(/<[^>]+>/g, "");
+
+	// Decode the handful of entities Tiptap commonly emits.
+	s = s.replace(/&nbsp;|&amp;|&lt;|&gt;|&quot;|&#39;|&apos;/g, (m) => ENTITIES[m] ?? m);
+
+	// Collapse runs of blank lines and normalize trailing whitespace.
+	s = s.replace(/\n{3,}/g, "\n\n");
+	return s.trim();
+}

--- a/src/lib/inline-emphasis.test.ts
+++ b/src/lib/inline-emphasis.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { parseInlineEmphasis } from "@/lib/inline-emphasis";
+
+describe("parseInlineEmphasis", () => {
+	it("returns plain text unchanged", () => {
+		expect(parseInlineEmphasis("hello world")).toEqual([
+			{ text: "hello world", bold: false, italic: false },
+		]);
+	});
+
+	it("parses **bold**", () => {
+		expect(parseInlineEmphasis("Built **scalable** APIs")).toEqual([
+			{ text: "Built ", bold: false, italic: false },
+			{ text: "scalable", bold: true, italic: false },
+			{ text: " APIs", bold: false, italic: false },
+		]);
+	});
+
+	it("parses *italic*", () => {
+		expect(parseInlineEmphasis("Used *Postgres* for storage")).toEqual([
+			{ text: "Used ", bold: false, italic: false },
+			{ text: "Postgres", bold: false, italic: true },
+			{ text: " for storage", bold: false, italic: false },
+		]);
+	});
+
+	it("parses bold and italic in the same string", () => {
+		expect(parseInlineEmphasis("**A** then *B* end")).toEqual([
+			{ text: "A", bold: true, italic: false },
+			{ text: " then ", bold: false, italic: false },
+			{ text: "B", bold: false, italic: true },
+			{ text: " end", bold: false, italic: false },
+		]);
+	});
+
+	it("does not double-match nested or empty markers", () => {
+		// Empty markers should fall through as plain text.
+		expect(parseInlineEmphasis("****")).toEqual([{ text: "****", bold: false, italic: false }]);
+	});
+
+	it("handles empty input", () => {
+		expect(parseInlineEmphasis("")).toEqual([{ text: "", bold: false, italic: false }]);
+	});
+});

--- a/src/lib/inline-emphasis.ts
+++ b/src/lib/inline-emphasis.ts
@@ -1,0 +1,38 @@
+export type EmphasisToken = {
+	text: string;
+	bold: boolean;
+	italic: boolean;
+};
+
+// Tokenize a string containing **bold** and *italic* markdown emphasis into
+// runs ready to feed into a DOCX TextRun. Bold is matched before italic so
+// `**x**` does not get parsed as `*` + `*x*` + `*`. Nested emphasis is not
+// supported — model output stays single-level.
+export function parseInlineEmphasis(input: string): EmphasisToken[] {
+	const tokens: EmphasisToken[] = [];
+	const pattern = /\*\*([^*]+)\*\*|\*([^*]+)\*/g;
+
+	let lastIndex = 0;
+	let match: RegExpExecArray | null = pattern.exec(input);
+	while (match !== null) {
+		if (match.index > lastIndex) {
+			tokens.push({
+				text: input.slice(lastIndex, match.index),
+				bold: false,
+				italic: false,
+			});
+		}
+		if (match[1] !== undefined) {
+			tokens.push({ text: match[1], bold: true, italic: false });
+		} else if (match[2] !== undefined) {
+			tokens.push({ text: match[2], bold: false, italic: true });
+		}
+		lastIndex = pattern.lastIndex;
+		match = pattern.exec(input);
+	}
+	if (lastIndex < input.length) {
+		tokens.push({ text: input.slice(lastIndex), bold: false, italic: false });
+	}
+
+	return tokens.length > 0 ? tokens : [{ text: input, bold: false, italic: false }];
+}


### PR DESCRIPTION
## Summary
Rewrites the DOCX export to consume \`TailoredCv\` JSON (from #7) and produce a CV-appropriate document instead of the default Word look.

- **Style tokens** (\`src/lib/cv-styles.ts\`): single source of truth — Calibri, 0.75\" margins, 1.15 line height, heading/body/contact sizes, accent color for links. The upcoming PDF renderer (#11) will consume the same tokens.
- **Inline emphasis** (\`src/lib/inline-emphasis.ts\`): small tokenizer that turns \`**bold**\` / \`*italic*\` inside bullet text into \`TextRun\`s. Bold matched before italic; nested emphasis not supported (model output is single-level). Unit-tested.
- **\`generateCvDocx(cv, title?)\`** (\`src/lib/export.ts\`): centered name + contact line with \`ExternalHyperlink\` for email and header URLs; H2 section headings with bottom border + \`keepNext\`; experience entries with **bold** company / *italic* role / right-tabbed dates; bullets use 0.25\" hanging indent and inline emphasis; education / projects / certifications follow the same patterns.
- **Cover letter path** (\`generateDocx(markdown, title?)\`) kept for back-compat and restyled with the same tokens, so cover letters get Calibri + 0.75\" margins too.
- **Export route** (\`src/app/api/applications/[id]/export/route.ts\`): for CV exports, prefers \`tailoredCvJson\`; falls back to \`markdownToJson(tailoredCVEdited)\` for legacy rows; degrades to the markdown renderer only if both fail to validate.

## Breaking change
None. Public API of \`generateDocx\` unchanged (still takes markdown). New \`generateCvDocx\` is additive.

## Test plan
- [x] \`pnpm exec vitest run src/lib\` — 34/34 pass (covers emphasis tokenizer, CV→DOCX rendering for full + minimal-empty-sections, and markdown→DOCX cover letter path).
- [x] \`pnpm type-check\` clean.
- [x] Biome lint clean on changed files.
- [ ] Manual: export a real tailored application as DOCX, open in Word/LibreOffice — verify Calibri throughout, hyperlinks clickable, section headings have bottom border, bold company / italic role render, dates right-aligned, no orphaned headings on a long CV.

## Acceptance criteria mapping (issue #10)
- [x] DOCX uses Calibri throughout
- [x] Bold company / italic role render correctly
- [x] Section headings have bottom border
- [x] Email and URLs are clickable hyperlinks
- [x] Margins 0.75\"
- [x] Headings carry \`keepNext\` so they don't orphan (verification pending visual review)
- [ ] Visual snapshot review against a known-good reference CV — pending manual export

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New, polished DOCX CV export with professional layout, section styling, and contact link support
  * Improved cover-letter and CV export handling with clearer eligibility rules and safer markdown/structured-data fallbacks
  * Centralized CV styling (fonts, sizes, spacing) used across exports
  * Better bold/italic rendering in exported documents and preserved inline emphasis

* **Tests**
  * Added tests validating DOCX output and inline emphasis parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->