### PR TITLE
fix(export): refuse degenerate markdown parses to avoid mangled PDFs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "^7.5.0",
     "@react-pdf/renderer": "^4.3.2",
-    "@tiptap/extension-link": "^3.20.2",
-    "@tiptap/extension-underline": "^3.20.2",
     "@tiptap/pm": "^3.20.2",
     "@tiptap/react": "^3.20.2",
     "@tiptap/starter-kit": "^3.20.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "^7.5.0",
     "@react-pdf/renderer": "^4.3.2",
+    "@tiptap/extension-link": "^3.20.2",
     "@tiptap/extension-underline": "^3.20.2",
     "@tiptap/pm": "^3.20.2",
     "@tiptap/react": "^3.20.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@react-pdf/renderer':
         specifier: ^4.3.2
         version: 4.3.2(react@19.2.3)
+      '@tiptap/extension-link':
+        specifier: ^3.20.2
+        version: 3.20.2(@tiptap/core@3.20.2(@tiptap/pm@3.20.2))(@tiptap/pm@3.20.2)
       '@tiptap/extension-underline':
         specifier: ^3.20.2
         version: 3.20.2(@tiptap/core@3.20.2(@tiptap/pm@3.20.2))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,12 +32,6 @@ importers:
       '@react-pdf/renderer':
         specifier: ^4.3.2
         version: 4.3.2(react@19.2.3)
-      '@tiptap/extension-link':
-        specifier: ^3.20.2
-        version: 3.20.2(@tiptap/core@3.20.2(@tiptap/pm@3.20.2))(@tiptap/pm@3.20.2)
-      '@tiptap/extension-underline':
-        specifier: ^3.20.2
-        version: 3.20.2(@tiptap/core@3.20.2(@tiptap/pm@3.20.2))
       '@tiptap/pm':
         specifier: ^3.20.2
         version: 3.20.2

--- a/src/app/api/applications/[id]/export/route.ts
+++ b/src/app/api/applications/[id]/export/route.ts
@@ -54,7 +54,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 		}
 		if (!cv) {
 			return NextResponse.json(
-				{ error: "Tailored CV JSON not available; cannot render PDF" },
+				{
+					error:
+						"Structured tailored CV not available — please re-run Tailor on this application to regenerate the data, then export again.",
+				},
 				{ status: 400 },
 			);
 		}

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -1,0 +1,20 @@
+import Link from "@tiptap/extension-link";
+import Underline from "@tiptap/extension-underline";
+import StarterKit from "@tiptap/starter-kit";
+
+// Shared extension list used by TiptapEditor (client) and round-trip tests
+// (jsdom). Co-locating the schema means a regression that removes Link or
+// changes its config is caught by the link-survival test in
+// `tiptap-editor.test.ts` instead of silently dropping <a> tags on save.
+export const editorExtensions = [
+	StarterKit.configure({
+		heading: { levels: [1, 2, 3] },
+	}),
+	Link.configure({
+		openOnClick: false,
+		autolink: false,
+		protocols: ["http", "https", "mailto", "tel"],
+		HTMLAttributes: { target: "_blank", rel: "noopener noreferrer" },
+	}),
+	Underline,
+];

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -1,20 +1,20 @@
-import Link from "@tiptap/extension-link";
-import Underline from "@tiptap/extension-underline";
 import StarterKit from "@tiptap/starter-kit";
 
 // Shared extension list used by TiptapEditor (client) and round-trip tests
-// (jsdom). Co-locating the schema means a regression that removes Link or
-// changes its config is caught by the link-survival test in
-// `tiptap-editor.test.ts` instead of silently dropping <a> tags on save.
+// (jsdom). StarterKit v3 already bundles Link and Underline, so we configure
+// them through StarterKit's options rather than registering separate
+// instances — registering a second `link` extension produces duplicate
+// schema entries and Tiptap's resolution between them is implementation-
+// defined. Co-locating here also means schema regressions are caught by the
+// link-survival tests in `tiptap-editor.test.ts`.
 export const editorExtensions = [
 	StarterKit.configure({
 		heading: { levels: [1, 2, 3] },
+		link: {
+			openOnClick: false,
+			autolink: false,
+			protocols: ["http", "https", "mailto", "tel"],
+			HTMLAttributes: { target: "_blank", rel: "noopener noreferrer" },
+		},
 	}),
-	Link.configure({
-		openOnClick: false,
-		autolink: false,
-		protocols: ["http", "https", "mailto", "tel"],
-		HTMLAttributes: { target: "_blank", rel: "noopener noreferrer" },
-	}),
-	Underline,
 ];

--- a/src/components/editor/tiptap-editor.test.ts
+++ b/src/components/editor/tiptap-editor.test.ts
@@ -1,0 +1,48 @@
+import { Editor } from "@tiptap/react";
+import { describe, expect, it } from "vitest";
+import { editorExtensions } from "@/components/editor/extensions";
+import { htmlToMarkdown } from "@/lib/html-to-markdown";
+import { markdownToHtml } from "@/lib/markdown-to-html";
+
+// These tests exercise the actual Tiptap schema used by TiptapEditor. A pure
+// markdownToHtml ↔ htmlToMarkdown round-trip cannot catch the regression where
+// StarterKit alone (no Link extension) silently strips <a> tags on parse —
+// only a real Editor instance does, since the schema lives in @tiptap/core.
+
+function loadAndExport(content: string): { html: string; markdown: string } {
+	const editor = new Editor({ extensions: editorExtensions, content });
+	const html = editor.getHTML();
+	editor.destroy();
+	return { html, markdown: htmlToMarkdown(html) };
+}
+
+describe("TiptapEditor schema", () => {
+	it("registers the link mark — without it, anchors are stripped on parse", () => {
+		// Direct schema assertion: if a future StarterKit upgrade or `link: false`
+		// config drops the mark, the round-trip test below also fails, but this
+		// gives a clearer error message about *why*.
+		const editor = new Editor({ extensions: editorExtensions, content: "" });
+		expect(Object.keys(editor.schema.marks)).toContain("link");
+		editor.destroy();
+	});
+
+	it("preserves markdown links across a load → getHTML → htmlToMarkdown round trip", () => {
+		const md = "Visit [Site](https://example.com) for details.";
+		const { html, markdown } = loadAndExport(markdownToHtml(md));
+
+		expect(html).toContain('href="https://example.com"');
+		expect(markdown).toContain("[Site](https://example.com)");
+	});
+
+	it("preserves multiple contact links the way a CV header would emit them", () => {
+		const md =
+			"# Jane Doe\n\n**Senior Engineer**\n\njane@example.com • [Website](https://example.com) • [LinkedIn](https://linkedin.com/in/jane)";
+		const { markdown } = loadAndExport(markdownToHtml(md));
+
+		expect(markdown).toContain("[Website](https://example.com)");
+		expect(markdown).toContain("[LinkedIn](https://linkedin.com/in/jane)");
+		// Title and name survive as block elements.
+		expect(markdown).toMatch(/# Jane Doe/);
+		expect(markdown).toContain("**Senior Engineer**");
+	});
+});

--- a/src/components/editor/tiptap-editor.test.ts
+++ b/src/components/editor/tiptap-editor.test.ts
@@ -26,6 +26,18 @@ describe("TiptapEditor schema", () => {
 		editor.destroy();
 	});
 
+	it("does not register duplicate extensions", () => {
+		// StarterKit v3 already bundles Link and Underline — registering a
+		// second instance produces two extensions with the same name and
+		// implementation-defined resolution. Lock in single-registration so a
+		// future contributor doesn't accidentally re-add `Link` to the array.
+		const editor = new Editor({ extensions: editorExtensions, content: "" });
+		const names = editor.extensionManager.extensions.map((x) => x.name);
+		const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+		editor.destroy();
+		expect(dupes).toEqual([]);
+	});
+
 	it("preserves markdown links across a load → getHTML → htmlToMarkdown round trip", () => {
 		const md = "Visit [Site](https://example.com) for details.";
 		const { html, markdown } = loadAndExport(markdownToHtml(md));

--- a/src/components/editor/tiptap-editor.tsx
+++ b/src/components/editor/tiptap-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Underline from "@tiptap/extension-underline";
@@ -17,8 +17,18 @@ import {
 	Underline as UnderlineIcon,
 	Undo,
 } from "lucide-react";
+import { looksLikeHtml } from "@/lib/cv-serializer";
+import { markdownToHtml } from "@/lib/markdown-to-html";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+
+// Tiptap interprets `content` as HTML. Our pipeline stores tailored CVs and
+// cover letters as markdown, so convert markdown → HTML on load. Legacy rows
+// that already contain HTML pass through untouched.
+function normalizeIncoming(content: string): string {
+	if (!content) return "";
+	return looksLikeHtml(content) ? content : markdownToHtml(content);
+}
 
 interface TiptapEditorProps {
 	content: string;
@@ -31,6 +41,8 @@ export function TiptapEditor({ content, onUpdate, editable = true, className }: 
 	const onUpdateRef = useRef(onUpdate);
 	onUpdateRef.current = onUpdate;
 
+	const initialHtml = useMemo(() => normalizeIncoming(content), [content]);
+
 	const editor = useEditor({
 		extensions: [
 			StarterKit.configure({
@@ -38,7 +50,7 @@ export function TiptapEditor({ content, onUpdate, editable = true, className }: 
 			}),
 			Underline,
 		],
-		content,
+		content: initialHtml,
 		editable,
 		immediatelyRender: false,
 		onUpdate: ({ editor: e }) => {
@@ -56,7 +68,7 @@ export function TiptapEditor({ content, onUpdate, editable = true, className }: 
 	useEffect(() => {
 		if (editor && content !== prevContentRef.current) {
 			prevContentRef.current = content;
-			editor.commands.setContent(content);
+			editor.commands.setContent(normalizeIncoming(content));
 		}
 	}, [editor, content]);
 

--- a/src/components/editor/tiptap-editor.tsx
+++ b/src/components/editor/tiptap-editor.tsx
@@ -2,10 +2,8 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
-import Underline from "@tiptap/extension-underline";
 import type { Editor } from "@tiptap/react";
+import { editorExtensions } from "@/components/editor/extensions";
 import {
 	Bold,
 	Heading1,
@@ -45,20 +43,7 @@ export function TiptapEditor({ content, onUpdate, editable = true, className }: 
 	const initialHtml = useMemo(() => normalizeIncoming(content), [content]);
 
 	const editor = useEditor({
-		extensions: [
-			StarterKit.configure({
-				heading: { levels: [1, 2, 3] },
-			}),
-			// Without Link, StarterKit's schema strips <a> tags on parse — markdown
-			// links emitted by markdownToHtml would be silently lost on save.
-			Link.configure({
-				openOnClick: false,
-				autolink: false,
-				protocols: ["http", "https", "mailto", "tel"],
-				HTMLAttributes: { target: "_blank", rel: "noopener noreferrer" },
-			}),
-			Underline,
-		],
+		extensions: editorExtensions,
 		content: initialHtml,
 		editable,
 		immediatelyRender: false,

--- a/src/components/editor/tiptap-editor.tsx
+++ b/src/components/editor/tiptap-editor.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import Link from "@tiptap/extension-link";
 import Underline from "@tiptap/extension-underline";
 import type { Editor } from "@tiptap/react";
 import {
@@ -47,6 +48,14 @@ export function TiptapEditor({ content, onUpdate, editable = true, className }: 
 		extensions: [
 			StarterKit.configure({
 				heading: { levels: [1, 2, 3] },
+			}),
+			// Without Link, StarterKit's schema strips <a> tags on parse — markdown
+			// links emitted by markdownToHtml would be silently lost on save.
+			Link.configure({
+				openOnClick: false,
+				autolink: false,
+				protocols: ["http", "https", "mailto", "tel"],
+				HTMLAttributes: { target: "_blank", rel: "noopener noreferrer" },
 			}),
 			Underline,
 		],

--- a/src/lib/cv-serializer.test.ts
+++ b/src/lib/cv-serializer.test.ts
@@ -158,7 +158,7 @@ describe("cv-serializer", () => {
 		// Reproduces the Tiptap-stored-as-literal-text failure mode: an entire CV
 		// collapsed onto a single line where `##` and `###` are not at line start.
 		const collapsed =
-			"Christian Diomampo Senior Full Stack Developer chrisgen19@gmail.com ## Summary ten years of experience ## Skills - React, Next.js ### Some Company — *Senior Dev*";
+			"Sample Candidate Senior Full Stack Developer candidate@example.com ## Summary ten years of experience ## Skills - React, Next.js ### Some Company — *Senior Dev*";
 		expect(() => markdownToJson(collapsed)).toThrow(/no recognizable sections/);
 	});
 

--- a/src/lib/cv-serializer.test.ts
+++ b/src/lib/cv-serializer.test.ts
@@ -138,6 +138,14 @@ describe("cv-serializer", () => {
 		expect(looksLikeHtml("Just plain text")).toBe(false);
 	});
 
+	it("refuses degenerate markdown where ## markers are not line-anchored", () => {
+		// Reproduces the Tiptap-stored-as-literal-text failure mode: an entire CV
+		// collapsed onto a single line where `##` and `###` are not at line start.
+		const collapsed =
+			"Christian Diomampo Senior Full Stack Developer chrisgen19@gmail.com ## Summary ten years of experience ## Skills - React, Next.js ### Some Company — *Senior Dev*";
+		expect(() => markdownToJson(collapsed)).toThrow(/no recognizable sections/);
+	});
+
 	it("handles markdown with missing optional sections", () => {
 		const minimal = "# John Smith\n\njohn@example.com\n\n## Summary\n\nMinimal CV.";
 		const parsed = markdownToJson(minimal);

--- a/src/lib/cv-serializer.test.ts
+++ b/src/lib/cv-serializer.test.ts
@@ -138,6 +138,22 @@ describe("cv-serializer", () => {
 		expect(looksLikeHtml("Just plain text")).toBe(false);
 	});
 
+	it("recovers title when an editor round-trip merged it onto the contact line", () => {
+		// jsonToMarkdown previously emitted **Title** and the contact line on
+		// consecutive lines (no blank between). CommonMark soft-break rules then
+		// caused markdown-to-html to merge them into one <p>; htmlToMarkdown on
+		// save produced a single line — we still want title recovered cleanly.
+		const merged =
+			"# Jane Doe\n**Senior Engineer** jane@example.com • +1 555 123 4567 • Remote • [Site](https://jane.dev)";
+		const parsed = markdownToJson(merged);
+		expect(parsed.header.name).toBe("Jane Doe");
+		expect(parsed.header.title).toBe("Senior Engineer");
+		expect(parsed.header.email).toBe("jane@example.com");
+		expect(parsed.header.phone).toBe("+1 555 123 4567");
+		expect(parsed.header.location).toBe("Remote");
+		expect(parsed.header.links[0]).toEqual({ label: "Site", url: "https://jane.dev" });
+	});
+
 	it("refuses degenerate markdown where ## markers are not line-anchored", () => {
 		// Reproduces the Tiptap-stored-as-literal-text failure mode: an entire CV
 		// collapsed onto a single line where `##` and `###` are not at line start.

--- a/src/lib/cv-serializer.ts
+++ b/src/lib/cv-serializer.ts
@@ -118,8 +118,21 @@ export function markdownToJson(markdown: string): TailoredCv {
 		throw new Error("Input is HTML, not markdown — refusing to parse");
 	}
 	const sections = splitIntoSections(markdown);
+	const header = parseHeader(sections.preamble);
+	// Guard against degenerate parses: when the source has no line-anchored `##`
+	// headings (e.g. Tiptap stored markdown as literal text inside <p> tags), the
+	// entire blob lands in header.name and every section comes back empty. Render
+	// would produce one giant bold "name" — refuse so the export route can return
+	// a clear error instead of silently emitting a mangled PDF/DOCX.
+	const sectionKeys = Object.keys(sections.byKey);
+	const looksDegenerate =
+		sectionKeys.length === 0 &&
+		(header.name.length > 200 || /(^|\s)#{2,3}\s/.test(header.name));
+	if (looksDegenerate) {
+		throw new Error("Markdown has no recognizable sections — refusing to parse");
+	}
 	const cv: TailoredCv = TailoredCvSchema.parse({
-		header: parseHeader(sections.preamble),
+		header,
 		summary: extractSummary(sections.byKey.summary),
 		skills: parseSkills(sections.byKey.skills),
 		experience: parseExperience(sections.byKey.experience),

--- a/src/lib/cv-serializer.ts
+++ b/src/lib/cv-serializer.ts
@@ -16,7 +16,11 @@ export function jsonToMarkdown(cv: TailoredCv): string {
 	const lines: string[] = [];
 
 	lines.push(`# ${cv.header.name}`);
-	if (cv.header.title) lines.push(`**${cv.header.title}**`);
+	// Blank lines turn each header component into its own paragraph. Without
+	// them, markdown-to-html collapses title + contact into a single <p> per
+	// CommonMark soft-break rules, and the editor round-trip then merges them
+	// so parseHeader can no longer detect the **title** line.
+	if (cv.header.title) lines.push("", `**${cv.header.title}**`);
 
 	const contactBits: string[] = [];
 	if (cv.header.email) contactBits.push(cv.header.email);
@@ -25,7 +29,7 @@ export function jsonToMarkdown(cv: TailoredCv): string {
 	for (const link of cv.header.links) {
 		contactBits.push(link.label ? `[${link.label}](${link.url})` : link.url);
 	}
-	if (contactBits.length > 0) lines.push(contactBits.join(" • "));
+	if (contactBits.length > 0) lines.push("", contactBits.join(" • "));
 
 	if (cv.summary?.trim()) {
 		lines.push("", `## ${SECTION_HEADINGS.summary}`, "", cv.summary.trim());
@@ -204,7 +208,21 @@ function parseHeader(preamble: string[]): TailoredCv["header"] {
 	let location: string | undefined;
 
 	for (const candidate of contactCandidates) {
-		const tokens = candidate.split(/\s*[•|]\s*/);
+		// Legacy round-trip recovery: when an editor save merged the **Title**
+		// line onto the contact line (because of CommonMark soft-break collapse),
+		// the candidate looks like "**Senior Dev** email@x.com • phone • ...".
+		// Extract the leading **bold** as the title and let the rest fall through
+		// to normal contact parsing.
+		let working = candidate;
+		if (!title) {
+			const merged = working.match(/^\*\*([^*]+)\*\*\s*(.*)$/);
+			if (merged) {
+				title = merged[1].trim();
+				working = merged[2].replace(/^[\s•|]+/, "");
+				if (!working) continue;
+			}
+		}
+		const tokens = working.split(/\s*[•|]\s*/);
 		for (const token of tokens) {
 			if (!token.trim()) continue;
 			const linkMatch = token.match(/^\[([^\]]+)\]\(([^)]+)\)$/);

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -269,6 +269,9 @@ Each experience and project bullet must:
 - Contain a quantified result when ORIGINAL CV provides one. Do not fabricate numbers to satisfy this rule.
 - Stay under 25 words. Trim filler words.
 
+RULE 6 — REFERENCE SECTIONS (preserve in full)
+Education and certifications are reference data, not narrative. Include EVERY education entry and EVERY certification from ORIGINAL CV — do not drop, summarize, or reorder them. The length budget in RULE 2 applies only to summary + experience + project + skills text. Header fields (name, title, email, phone, location, links) must be plain text — never wrap them in \`**\`, \`*\`, or other markdown markers.
+
 OUTPUT
 Return JSON matching the provided response schema. Do not return markdown, explanations, or commentary outside the schema. Reorder \`experience\` so the most JD-relevant role appears first.`;
 

--- a/src/lib/markdown-to-html.test.ts
+++ b/src/lib/markdown-to-html.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { htmlToMarkdown } from "@/lib/html-to-markdown";
 import { markdownToHtml } from "@/lib/markdown-to-html";
 
 describe("markdownToHtml", () => {
@@ -48,5 +49,21 @@ describe("markdownToHtml", () => {
 
 	it("returns empty string for empty input", () => {
 		expect(markdownToHtml("")).toBe("");
+	});
+
+	it("rejects unsafe protocols and renders the literal markdown instead", () => {
+		expect(markdownToHtml("[click](javascript:alert(1))")).toBe(
+			"<p>[click](javascript:alert(1))</p>",
+		);
+		expect(markdownToHtml("[mail](mailto:hi@example.com)")).toBe(
+			'<p><a href="mailto:hi@example.com" target="_blank" rel="noopener noreferrer">mail</a></p>',
+		);
+	});
+
+	it("links survive a markdown → HTML → markdown round trip", () => {
+		const md = "Visit [Site](https://example.com) and [GitHub](https://github.com/x).";
+		const roundTripped = htmlToMarkdown(markdownToHtml(md));
+		expect(roundTripped).toContain("[Site](https://example.com)");
+		expect(roundTripped).toContain("[GitHub](https://github.com/x)");
 	});
 });

--- a/src/lib/markdown-to-html.test.ts
+++ b/src/lib/markdown-to-html.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { markdownToHtml } from "@/lib/markdown-to-html";
+
+describe("markdownToHtml", () => {
+	it("converts headings and paragraphs", () => {
+		const md = "# Title\n\n## Section\n\nA paragraph.";
+		expect(markdownToHtml(md)).toBe(
+			"<h1>Title</h1><h2>Section</h2><p>A paragraph.</p>",
+		);
+	});
+
+	it("clamps headings beyond h3 to match Tiptap config", () => {
+		expect(markdownToHtml("#### Deep")).toBe("<h3>Deep</h3>");
+	});
+
+	it("converts bullet lists with inline emphasis", () => {
+		const md = "- **First** item\n- *Second* item";
+		expect(markdownToHtml(md)).toBe(
+			"<ul><li><strong>First</strong> item</li><li><em>Second</em> item</li></ul>",
+		);
+	});
+
+	it("renders links with safe target+rel attributes", () => {
+		const md = "Visit [my site](https://example.com) for more.";
+		expect(markdownToHtml(md)).toBe(
+			'<p>Visit <a href="https://example.com" target="_blank" rel="noopener noreferrer">my site</a> for more.</p>',
+		);
+	});
+
+	it("escapes HTML entities in plain text", () => {
+		expect(markdownToHtml("a < b & c > d")).toBe(
+			"<p>a &lt; b &amp; c &gt; d</p>",
+		);
+	});
+
+	it("handles bold-then-italic without crossing tag boundaries", () => {
+		expect(markdownToHtml("**bold** and *italic*")).toBe(
+			"<p><strong>bold</strong> and <em>italic</em></p>",
+		);
+	});
+
+	it("treats blank lines as paragraph breaks and closes lists", () => {
+		const md = "Para one.\n\n- item\n\nPara two.";
+		expect(markdownToHtml(md)).toBe(
+			"<p>Para one.</p><ul><li>item</li></ul><p>Para two.</p>",
+		);
+	});
+
+	it("returns empty string for empty input", () => {
+		expect(markdownToHtml("")).toBe("");
+	});
+});

--- a/src/lib/markdown-to-html.ts
+++ b/src/lib/markdown-to-html.ts
@@ -16,13 +16,17 @@ function escapeHtml(s: string): string {
 	return s.replace(/[&<>"']/g, (c) => ESC_MAP[c] ?? c);
 }
 
+const SAFE_PROTOCOL = /^(?:https?|mailto|tel):/i;
+
 // Inline pass: links → emphasis. Order matters — we escape first, then inject
 // tags so user-supplied `<` in plain text never escapes the encoder.
 function renderInline(raw: string): string {
 	let s = escapeHtml(raw);
 	// [label](url) — both sides are already HTML-escaped, so quotes in URL are
-	// encoded; that's fine for href attributes.
-	s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, label, url) => {
+	// encoded; that's fine for href attributes. Reject protocols outside the
+	// allowlist (e.g. `javascript:`) — render as plain text instead.
+	s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, label, url) => {
+		if (!SAFE_PROTOCOL.test(url)) return match;
 		return `<a href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`;
 	});
 	// **bold** before *italic* so `**x**` doesn't get eaten by the italic regex.

--- a/src/lib/markdown-to-html.ts
+++ b/src/lib/markdown-to-html.ts
@@ -1,0 +1,91 @@
+// Convert the narrow markdown subset our pipeline emits (jsonToMarkdown output:
+// headings, paragraphs, bullets, inline emphasis, links) into HTML that Tiptap
+// can render. Keeping this in-tree avoids pulling in marked/remark for what
+// is, in practice, a fixed grammar. The inverse converter lives in
+// `html-to-markdown.ts` and the two should evolve together.
+
+const ESC_MAP: Record<string, string> = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	'"': "&quot;",
+	"'": "&#39;",
+};
+
+function escapeHtml(s: string): string {
+	return s.replace(/[&<>"']/g, (c) => ESC_MAP[c] ?? c);
+}
+
+// Inline pass: links → emphasis. Order matters — we escape first, then inject
+// tags so user-supplied `<` in plain text never escapes the encoder.
+function renderInline(raw: string): string {
+	let s = escapeHtml(raw);
+	// [label](url) — both sides are already HTML-escaped, so quotes in URL are
+	// encoded; that's fine for href attributes.
+	s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, label, url) => {
+		return `<a href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+	});
+	// **bold** before *italic* so `**x**` doesn't get eaten by the italic regex.
+	s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+	s = s.replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, "$1<em>$2</em>");
+	return s;
+}
+
+export function markdownToHtml(markdown: string): string {
+	const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+	const out: string[] = [];
+	let inList = false;
+
+	const closeList = () => {
+		if (inList) {
+			out.push("</ul>");
+			inList = false;
+		}
+	};
+
+	const paragraphBuf: string[] = [];
+	const flushParagraph = () => {
+		if (paragraphBuf.length === 0) return;
+		const text = paragraphBuf.join(" ").trim();
+		paragraphBuf.length = 0;
+		if (text) out.push(`<p>${renderInline(text)}</p>`);
+	};
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+
+		if (!trimmed) {
+			flushParagraph();
+			closeList();
+			continue;
+		}
+
+		const heading = trimmed.match(/^(#{1,6})\s+(.+)$/);
+		if (heading) {
+			flushParagraph();
+			closeList();
+			const level = Math.min(heading[1].length, 3); // Tiptap is configured for h1–h3
+			out.push(`<h${level}>${renderInline(heading[2].trim())}</h${level}>`);
+			continue;
+		}
+
+		const bullet = trimmed.match(/^[-*]\s+(.+)$/);
+		if (bullet) {
+			flushParagraph();
+			if (!inList) {
+				out.push("<ul>");
+				inList = true;
+			}
+			out.push(`<li>${renderInline(bullet[1].trim())}</li>`);
+			continue;
+		}
+
+		closeList();
+		paragraphBuf.push(trimmed);
+	}
+
+	flushParagraph();
+	closeList();
+
+	return out.join("");
+}


### PR DESCRIPTION
Closes #21

## Summary
- `markdownToJson` now throws when a parse yields zero sections and `header.name` shows signs of having absorbed the whole document (>200 chars or contains mid-line `##`/`###`). Mirrors the existing `looksLikeHtml` guard.
- Export route returns a clearer 400 telling the user to re-run Tailor when structured CV data is unavailable.
- Test added covering the collapsed-Tiptap failure mode that triggered the bug on application `cmmsv6q2m0001t2m3b11ev1n3`.

See #21 for the full root-cause writeup.

## Test plan
- [x] `pnpm vitest run src/lib/cv-serializer.test.ts` — 6/6 pass
- [x] `pnpm tsc --noEmit` — clean
- [ ] Manually re-tailor the affected application and confirm PDF/DOCX render correctly via the structured renderer
- [ ] Manually trigger export on an application with no `tailoredCvJson` and confirm the new 400 message surfaces in the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in markdown→HTML conversion with safe link handling and consistent heading/list rendering.
  * Editor normalizes incoming content and adds a shared extension config to support links, underline, and clamped headings.

* **Bug Fixes**
  * Clearer PDF export error when structured CV data is missing.
  * Tailoring preserves education/certifications exactly and enforces plain-text header fields.
  * Better detection and rejection of malformed CV/header content.

* **Tests**
  * Added tests covering markdown→HTML, editor link round-trips, and malformed CV/header cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->