### PR TITLE
feat(applications): compensation + work setup fields (Phase 1 of #23)

### DIFF
--- a/prisma/migrations/20260427190945_add_application_compensation_and_work_setup/migration.sql
+++ b/prisma/migrations/20260427190945_add_application_compensation_and_work_setup/migration.sql
@@ -1,0 +1,13 @@
+-- CreateEnum
+CREATE TYPE "WorkSetup" AS ENUM ('REMOTE', 'HYBRID', 'ONSITE');
+
+-- AlterTable
+ALTER TABLE "JobApplication" ADD COLUMN     "salaryMin" INTEGER,
+ADD COLUMN     "salaryMax" INTEGER,
+ADD COLUMN     "salaryCurrency" TEXT,
+ADD COLUMN     "workSetup" "WorkSetup",
+ADD COLUMN     "locationAddress" TEXT,
+ADD COLUMN     "companyWebsite" TEXT,
+ADD COLUMN     "contactName" TEXT,
+ADD COLUMN     "contactEmail" TEXT,
+ADD COLUMN     "contactPhone" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,15 @@ model JobApplication {
   status             ApplicationStatus @default(DRAFT)
   notes              String?           @db.Text
   appliedAt          DateTime?
+  salaryMin          Int?
+  salaryMax          Int?
+  salaryCurrency     String?
+  workSetup          WorkSetup?
+  locationAddress    String?
+  companyWebsite     String?
+  contactName        String?
+  contactEmail       String?
+  contactPhone       String?
   createdAt          DateTime          @default(now())
   updatedAt          DateTime          @updatedAt
 
@@ -118,4 +127,10 @@ enum ApplicationStatus {
   REJECTED
   INTERVIEW
   OFFER
+}
+
+enum WorkSetup {
+  REMOTE
+  HYBRID
+  ONSITE
 }

--- a/src/app/(dashboard)/applications/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/applications/[id]/edit/page.tsx
@@ -1,17 +1,30 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import type { ApplicationStatus } from "@/generated/prisma/enums";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+	CompensationFields,
+	type CompensationValue,
+	compensationFromApplication,
+	compensationToPayload,
+	EMPTY_COMPENSATION,
+} from "@/components/applications/compensation-fields";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { toast } from "sonner";
+import type { ApplicationStatus } from "@/generated/prisma/enums";
 
 const STATUSES: { value: ApplicationStatus; label: string }[] = [
 	{ value: "DRAFT", label: "Draft" },
@@ -35,6 +48,7 @@ export default function EditApplicationPage() {
 	const [rawDescription, setRawDescription] = useState("");
 	const [status, setStatus] = useState<ApplicationStatus>("DRAFT");
 	const [notes, setNotes] = useState("");
+	const [compensation, setCompensation] = useState<CompensationValue>(EMPTY_COMPENSATION);
 
 	useEffect(() => {
 		async function load() {
@@ -47,6 +61,7 @@ export default function EditApplicationPage() {
 				setRawDescription(app.rawDescription);
 				setStatus(app.status);
 				setNotes(app.notes ?? "");
+				setCompensation(compensationFromApplication(app));
 			} catch {
 				toast.error("Failed to load application");
 				router.push("/applications");
@@ -63,6 +78,16 @@ export default function EditApplicationPage() {
 			return;
 		}
 
+		const compPayload = compensationToPayload(compensation);
+		if (
+			compPayload.salaryMin != null &&
+			compPayload.salaryMax != null &&
+			compPayload.salaryMax < compPayload.salaryMin
+		) {
+			toast.error("Max salary must be greater than or equal to min salary");
+			return;
+		}
+
 		setSubmitting(true);
 		try {
 			const res = await fetch(`/api/applications/${id}`, {
@@ -74,6 +99,7 @@ export default function EditApplicationPage() {
 					rawDescription: rawDescription.trim(),
 					status,
 					notes: notes.trim() || undefined,
+					...compPayload,
 				}),
 			});
 			if (!res.ok) {
@@ -117,19 +143,11 @@ export default function EditApplicationPage() {
 					<div className="grid gap-4 sm:grid-cols-2">
 						<div className="space-y-2">
 							<Label htmlFor="title">Job Title</Label>
-							<Input
-								id="title"
-								value={title}
-								onChange={(e) => setTitle(e.target.value)}
-							/>
+							<Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} />
 						</div>
 						<div className="space-y-2">
 							<Label htmlFor="company">Company</Label>
-							<Input
-								id="company"
-								value={company}
-								onChange={(e) => setCompany(e.target.value)}
-							/>
+							<Input id="company" value={company} onChange={(e) => setCompany(e.target.value)} />
 						</div>
 					</div>
 					<div className="space-y-2">
@@ -167,6 +185,8 @@ export default function EditApplicationPage() {
 					</div>
 				</CardContent>
 			</Card>
+
+			<CompensationFields value={compensation} onChange={setCompensation} />
 
 			<div className="flex justify-end gap-3">
 				<Button variant="outline" render={<Link href={`/applications/${id}`} />}>

--- a/src/app/(dashboard)/applications/[id]/page.tsx
+++ b/src/app/(dashboard)/applications/[id]/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
 import {
 	ArrowLeft,
@@ -20,9 +19,9 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import type { JobApplication } from "@/generated/prisma/client";
-import type { MatchAnalysis, ParsedRequirements } from "@/lib/gemini";
-import { cn } from "@/lib/utils";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { JobDetailsPanel } from "@/components/applications/job-details-panel";
 import { MatchScoreRing } from "@/components/applications/match-score-ring";
 import { StatusBadge } from "@/components/applications/status-badge";
 import { TiptapEditor } from "@/components/editor/tiptap-editor";
@@ -38,7 +37,9 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { toast } from "sonner";
+import type { JobApplication } from "@/generated/prisma/client";
+import type { MatchAnalysis, ParsedRequirements } from "@/lib/gemini";
+import { cn } from "@/lib/utils";
 
 export default function ApplicationDetailPage() {
 	const { id } = useParams<{ id: string }>();
@@ -60,7 +61,9 @@ export default function ApplicationDetailPage() {
 	const [savedCL, setSavedCL] = useState(false);
 
 	// Regenerate confirmation
-	const [confirmRegenerate, setConfirmRegenerate] = useState<"tailor" | "cover-letter" | null>(null);
+	const [confirmRegenerate, setConfirmRegenerate] = useState<"tailor" | "cover-letter" | null>(
+		null,
+	);
 
 	const fetchApplication = useCallback(async () => {
 		try {
@@ -266,11 +269,7 @@ export default function ApplicationDetailPage() {
 					</div>
 				</div>
 				<div className="flex gap-2">
-					<Button
-						variant="outline"
-						size="sm"
-						render={<Link href={`/applications/${id}/edit`} />}
-					>
+					<Button variant="outline" size="sm" render={<Link href={`/applications/${id}/edit`} />}>
 						<Pencil className="mr-1.5 h-3.5 w-3.5" />
 						Edit
 					</Button>
@@ -313,6 +312,8 @@ export default function ApplicationDetailPage() {
 
 				{/* ─── Job Description Tab ─────────────────────────────────── */}
 				<TabsContent value="description" className="mt-4 space-y-4">
+					<JobDetailsPanel application={application} />
+
 					<Card>
 						<CardHeader>
 							<CardTitle>Job Description</CardTitle>
@@ -544,19 +545,11 @@ export default function ApplicationDetailPage() {
 										<Clipboard className="mr-1.5 h-3.5 w-3.5" />
 										Copy
 									</Button>
-									<Button
-										variant="outline"
-										size="sm"
-										onClick={() => downloadExport("cv", "docx")}
-									>
+									<Button variant="outline" size="sm" onClick={() => downloadExport("cv", "docx")}>
 										<Download className="mr-1.5 h-3.5 w-3.5" />
 										DOCX
 									</Button>
-									<Button
-										variant="outline"
-										size="sm"
-										onClick={() => downloadExport("cv", "pdf")}
-									>
+									<Button variant="outline" size="sm" onClick={() => downloadExport("cv", "pdf")}>
 										<Download className="mr-1.5 h-3.5 w-3.5" />
 										PDF
 									</Button>
@@ -593,10 +586,7 @@ export default function ApplicationDetailPage() {
 										? "Generate an AI-tailored version of your CV optimized for this job."
 										: "Run match analysis first, then generate a tailored CV."}
 								</p>
-								<Button
-									onClick={handleTailor}
-									disabled={tailoring || !matchAnalysis}
-								>
+								<Button onClick={handleTailor} disabled={tailoring || !matchAnalysis}>
 									{tailoring ? (
 										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
 									) : (
@@ -697,7 +687,10 @@ export default function ApplicationDetailPage() {
 			</Dialog>
 
 			{/* Regenerate Confirmation Dialog */}
-			<Dialog open={!!confirmRegenerate} onOpenChange={(open) => !open && setConfirmRegenerate(null)}>
+			<Dialog
+				open={!!confirmRegenerate}
+				onOpenChange={(open) => !open && setConfirmRegenerate(null)}
+			>
 				<DialogContent>
 					<DialogHeader>
 						<DialogTitle>Regenerate Content</DialogTitle>

--- a/src/app/(dashboard)/applications/new/page.tsx
+++ b/src/app/(dashboard)/applications/new/page.tsx
@@ -1,16 +1,22 @@
 "use client";
 
-import { useState } from "react";
 import { ArrowLeft, Globe, Loader2, Type } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+	CompensationFields,
+	type CompensationValue,
+	compensationToPayload,
+	EMPTY_COMPENSATION,
+} from "@/components/applications/compensation-fields";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-import { toast } from "sonner";
 
 export default function NewApplicationPage() {
 	const router = useRouter();
@@ -22,6 +28,7 @@ export default function NewApplicationPage() {
 	const [rawDescription, setRawDescription] = useState("");
 	const [sourceUrl, setSourceUrl] = useState("");
 	const [notes, setNotes] = useState("");
+	const [compensation, setCompensation] = useState<CompensationValue>(EMPTY_COMPENSATION);
 
 	// Scrape state
 	const [scrapeUrl, setScrapeUrl] = useState("");
@@ -62,6 +69,16 @@ export default function NewApplicationPage() {
 			return;
 		}
 
+		const compPayload = compensationToPayload(compensation);
+		if (
+			compPayload.salaryMin != null &&
+			compPayload.salaryMax != null &&
+			compPayload.salaryMax < compPayload.salaryMin
+		) {
+			toast.error("Max salary must be greater than or equal to min salary");
+			return;
+		}
+
 		setSubmitting(true);
 		try {
 			const res = await fetch("/api/applications", {
@@ -73,6 +90,7 @@ export default function NewApplicationPage() {
 					rawDescription: rawDescription.trim(),
 					sourceUrl: sourceUrl.trim() || undefined,
 					notes: notes.trim() || undefined,
+					...compPayload,
 				}),
 			});
 			if (!res.ok) {
@@ -214,6 +232,8 @@ export default function NewApplicationPage() {
 					</div>
 				</CardContent>
 			</Card>
+
+			<CompensationFields value={compensation} onChange={setCompensation} />
 
 			<div className="flex justify-end gap-3">
 				<Button variant="outline" render={<Link href="/applications" />}>

--- a/src/app/api/applications/[id]/route.test.ts
+++ b/src/app/api/applications/[id]/route.test.ts
@@ -1,5 +1,51 @@
 import { describe, expect, it } from "vitest";
-import { resolveEditedTailoredCvJson } from "./route";
+import { normalizeEmptyStringsToNull, resolveEditedTailoredCvJson } from "./route";
+
+describe("normalizeEmptyStringsToNull", () => {
+	it("rewrites empty strings to null for the listed nullable text fields", () => {
+		const result = normalizeEmptyStringsToNull({
+			salaryCurrency: "",
+			locationAddress: "",
+			companyWebsite: "",
+			contactName: "",
+			contactEmail: "",
+			contactPhone: "",
+		});
+		expect(result).toEqual({
+			salaryCurrency: null,
+			locationAddress: null,
+			companyWebsite: null,
+			contactName: null,
+			contactEmail: null,
+			contactPhone: null,
+		});
+	});
+
+	it("preserves non-empty strings", () => {
+		const result = normalizeEmptyStringsToNull({
+			contactEmail: "jane@example.com",
+			contactName: "Jane",
+		});
+		expect(result.contactEmail).toBe("jane@example.com");
+		expect(result.contactName).toBe("Jane");
+	});
+
+	it("leaves explicit null values alone", () => {
+		const result = normalizeEmptyStringsToNull({ companyWebsite: null });
+		expect(result.companyWebsite).toBeNull();
+	});
+
+	it("does not touch fields outside the nullable text list", () => {
+		const input = { contactName: "Jane", title: "" } as unknown as {
+			salaryCurrency?: string | null;
+			contactName?: string | null;
+		};
+		const result = normalizeEmptyStringsToNull(input);
+		// title is an empty string but is not in NULLABLE_TEXT_FIELDS, so it stays.
+		expect((result as unknown as { title: string }).title).toBe("");
+		expect(result.contactName).toBe("Jane");
+	});
+});
 
 describe("resolveEditedTailoredCvJson", () => {
 	it("leaves JSON untouched when tailoredCVEdited is absent from the patch", () => {

--- a/src/app/api/applications/[id]/route.ts
+++ b/src/app/api/applications/[id]/route.ts
@@ -22,10 +22,7 @@ async function getApplication(userId: string, id: string) {
  */
 export function resolveEditedTailoredCvJson(
 	edited: string | undefined,
-):
-	| { kind: "leave" }
-	| { kind: "clear" }
-	| { kind: "set"; value: Prisma.InputJsonValue } {
+): { kind: "leave" } | { kind: "clear" } | { kind: "set"; value: Prisma.InputJsonValue } {
 	if (edited === undefined) return { kind: "leave" };
 	if (!edited.trim()) return { kind: "clear" };
 	try {
@@ -94,6 +91,16 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 	}
 
 	const data: Prisma.JobApplicationUpdateInput = { ...parsed.data };
+	for (const key of [
+		"salaryCurrency",
+		"locationAddress",
+		"companyWebsite",
+		"contactName",
+		"contactEmail",
+		"contactPhone",
+	] as const) {
+		if (data[key] === "") data[key] = null;
+	}
 	const decision = resolveEditedTailoredCvJson(parsed.data.tailoredCVEdited);
 	if (decision.kind === "set") data.tailoredCvJson = decision.value;
 	else if (decision.kind === "clear") data.tailoredCvJson = Prisma.JsonNull;
@@ -106,10 +113,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 	return NextResponse.json(updated);
 }
 
-export async function DELETE(
-	_request: Request,
-	{ params }: { params: Promise<{ id: string }> },
-) {
+export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
 	const session = await auth.api.getSession({ headers: await headers() });
 	if (!session) {
 		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/applications/[id]/route.ts
+++ b/src/app/api/applications/[id]/route.ts
@@ -33,6 +33,29 @@ export function resolveEditedTailoredCvJson(
 	}
 }
 
+/**
+ * Optional text fields where an empty string from a cleared form input should
+ * become a real DB NULL instead of being persisted as "". Keeps queries and
+ * downstream display logic free of "" sentinels.
+ */
+const NULLABLE_TEXT_FIELDS = [
+	"salaryCurrency",
+	"locationAddress",
+	"companyWebsite",
+	"contactName",
+	"contactEmail",
+	"contactPhone",
+] as const;
+
+export function normalizeEmptyStringsToNull<
+	T extends Partial<Record<(typeof NULLABLE_TEXT_FIELDS)[number], unknown>>,
+>(data: T): T {
+	for (const key of NULLABLE_TEXT_FIELDS) {
+		if (data[key] === "") data[key] = null as T[(typeof NULLABLE_TEXT_FIELDS)[number]];
+	}
+	return data;
+}
+
 async function backfillTailoredCvJson(id: string, markdown: string) {
 	try {
 		const parsed = markdownToJson(markdown);
@@ -90,17 +113,9 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 		);
 	}
 
-	const data: Prisma.JobApplicationUpdateInput = { ...parsed.data };
-	for (const key of [
-		"salaryCurrency",
-		"locationAddress",
-		"companyWebsite",
-		"contactName",
-		"contactEmail",
-		"contactPhone",
-	] as const) {
-		if (data[key] === "") data[key] = null;
-	}
+	const data: Prisma.JobApplicationUpdateInput = normalizeEmptyStringsToNull({
+		...parsed.data,
+	});
 	const decision = resolveEditedTailoredCvJson(parsed.data.tailoredCVEdited);
 	if (decision.kind === "set") data.tailoredCvJson = decision.value;
 	else if (decision.kind === "clear") data.tailoredCvJson = Prisma.JsonNull;

--- a/src/app/api/applications/route.ts
+++ b/src/app/api/applications/route.ts
@@ -59,14 +59,24 @@ export async function POST(request: Request) {
 		);
 	}
 
+	const d = parsed.data;
 	const application = await prisma.jobApplication.create({
 		data: {
 			userId: session.user.id,
-			title: parsed.data.title,
-			company: parsed.data.company,
-			sourceUrl: parsed.data.sourceUrl || null,
-			rawDescription: parsed.data.rawDescription,
-			notes: parsed.data.notes || null,
+			title: d.title,
+			company: d.company,
+			sourceUrl: d.sourceUrl || null,
+			rawDescription: d.rawDescription,
+			notes: d.notes || null,
+			salaryMin: d.salaryMin ?? null,
+			salaryMax: d.salaryMax ?? null,
+			salaryCurrency: d.salaryCurrency || null,
+			workSetup: d.workSetup ?? null,
+			locationAddress: d.locationAddress || null,
+			companyWebsite: d.companyWebsite || null,
+			contactName: d.contactName || null,
+			contactEmail: d.contactEmail || null,
+			contactPhone: d.contactPhone || null,
 		},
 	});
 

--- a/src/components/applications/application-card.tsx
+++ b/src/components/applications/application-card.tsx
@@ -1,9 +1,17 @@
 "use client";
 
 import { formatDistanceToNow } from "date-fns";
-import { Building2, Calendar, ExternalLink, MoreVertical, Pencil, Trash2 } from "lucide-react";
+import {
+	Banknote,
+	Briefcase,
+	Building2,
+	Calendar,
+	ExternalLink,
+	MoreVertical,
+	Pencil,
+	Trash2,
+} from "lucide-react";
 import Link from "next/link";
-import type { JobApplication } from "@/generated/prisma/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -12,6 +20,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import type { JobApplication } from "@/generated/prisma/client";
 import { StatusBadge } from "./status-badge";
 
 interface ApplicationCardProps {
@@ -21,7 +30,34 @@ interface ApplicationCardProps {
 	onDelete: (id: string) => void;
 }
 
-export function ApplicationCard({ application, selected, onSelect, onDelete }: ApplicationCardProps) {
+const WORK_SETUP_SHORT: Record<NonNullable<JobApplication["workSetup"]>, string> = {
+	REMOTE: "Remote",
+	HYBRID: "Hybrid",
+	ONSITE: "Onsite",
+};
+
+function compactSalary(min: number | null, max: number | null, currency: string | null) {
+	if (min == null && max == null) return null;
+	const cur = currency ?? "PHP";
+	const fmt = (n: number) => (n >= 1000 ? `${Math.round(n / 1000)}k` : String(n));
+	if (min != null && max != null) return `${cur} ${fmt(min)}–${fmt(max)}/mo`;
+	if (min != null) return `${cur} ${fmt(min)}+/mo`;
+	return `≤ ${cur} ${fmt(max!)}/mo`;
+}
+
+export function ApplicationCard({
+	application,
+	selected,
+	onSelect,
+	onDelete,
+}: ApplicationCardProps) {
+	const salary = compactSalary(
+		application.salaryMin,
+		application.salaryMax,
+		application.salaryCurrency,
+	);
+	const setupLabel = application.workSetup ? WORK_SETUP_SHORT[application.workSetup] : null;
+
 	return (
 		<Card size="sm" className="group relative transition-colors hover:ring-primary/30">
 			<CardHeader>
@@ -44,7 +80,7 @@ export function ApplicationCard({ application, selected, onSelect, onDelete }: A
 							</CardTitle>
 							<StatusBadge status={application.status} />
 						</div>
-						<div className="flex items-center gap-3 text-xs text-muted-foreground">
+						<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
 							<span className="flex items-center gap-1">
 								<Building2 className="h-3 w-3" />
 								{application.company}
@@ -53,6 +89,18 @@ export function ApplicationCard({ application, selected, onSelect, onDelete }: A
 								<Calendar className="h-3 w-3" />
 								{formatDistanceToNow(new Date(application.createdAt), { addSuffix: true })}
 							</span>
+							{salary ? (
+								<span className="flex items-center gap-1">
+									<Banknote className="h-3 w-3" />
+									{salary}
+								</span>
+							) : null}
+							{setupLabel ? (
+								<span className="flex items-center gap-1 rounded-md bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+									<Briefcase className="h-3 w-3" />
+									{setupLabel}
+								</span>
+							) : null}
 						</div>
 					</div>
 					<DropdownMenu>
@@ -66,7 +114,9 @@ export function ApplicationCard({ application, selected, onSelect, onDelete }: A
 							</DropdownMenuItem>
 							{application.sourceUrl && (
 								<DropdownMenuItem
-									onSelect={() => window.open(application.sourceUrl!, "_blank", "noopener,noreferrer")}
+									onSelect={() =>
+										window.open(application.sourceUrl!, "_blank", "noopener,noreferrer")
+									}
 								>
 									<ExternalLink className="mr-2 h-3.5 w-3.5" />
 									View posting

--- a/src/components/applications/application-card.tsx
+++ b/src/components/applications/application-card.tsx
@@ -21,6 +21,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { JobApplication } from "@/generated/prisma/client";
+import { WORK_SETUP_LABELS } from "./compensation-fields";
 import { StatusBadge } from "./status-badge";
 
 interface ApplicationCardProps {
@@ -30,16 +31,11 @@ interface ApplicationCardProps {
 	onDelete: (id: string) => void;
 }
 
-const WORK_SETUP_SHORT: Record<NonNullable<JobApplication["workSetup"]>, string> = {
-	REMOTE: "Remote",
-	HYBRID: "Hybrid",
-	ONSITE: "Onsite",
-};
-
 function compactSalary(min: number | null, max: number | null, currency: string | null) {
 	if (min == null && max == null) return null;
 	const prefix = currency?.trim() ? `${currency.trim()} ` : "";
-	const fmt = (n: number) => (n >= 1000 ? `${Math.round(n / 1000)}k` : String(n));
+	// Math.floor so the compact label never overstates pay (e.g. 1501 → "1k", not "2k").
+	const fmt = (n: number) => (n >= 1000 ? `${Math.floor(n / 1000)}k` : String(n));
 	if (min != null && max != null) return `${prefix}${fmt(min)}–${fmt(max)}/mo`;
 	if (min != null) return `${prefix}${fmt(min)}+/mo`;
 	return `≤ ${prefix}${fmt(max!)}/mo`;
@@ -56,7 +52,7 @@ export function ApplicationCard({
 		application.salaryMax,
 		application.salaryCurrency,
 	);
-	const setupLabel = application.workSetup ? WORK_SETUP_SHORT[application.workSetup] : null;
+	const setupLabel = application.workSetup ? WORK_SETUP_LABELS[application.workSetup] : null;
 
 	return (
 		<Card size="sm" className="group relative transition-colors hover:ring-primary/30">

--- a/src/components/applications/application-card.tsx
+++ b/src/components/applications/application-card.tsx
@@ -38,11 +38,11 @@ const WORK_SETUP_SHORT: Record<NonNullable<JobApplication["workSetup"]>, string>
 
 function compactSalary(min: number | null, max: number | null, currency: string | null) {
 	if (min == null && max == null) return null;
-	const cur = currency ?? "PHP";
+	const prefix = currency?.trim() ? `${currency.trim()} ` : "";
 	const fmt = (n: number) => (n >= 1000 ? `${Math.round(n / 1000)}k` : String(n));
-	if (min != null && max != null) return `${cur} ${fmt(min)}–${fmt(max)}/mo`;
-	if (min != null) return `${cur} ${fmt(min)}+/mo`;
-	return `≤ ${cur} ${fmt(max!)}/mo`;
+	if (min != null && max != null) return `${prefix}${fmt(min)}–${fmt(max)}/mo`;
+	if (min != null) return `${prefix}${fmt(min)}+/mo`;
+	return `≤ ${prefix}${fmt(max!)}/mo`;
 }
 
 export function ApplicationCard({

--- a/src/components/applications/compensation-fields.test.ts
+++ b/src/components/applications/compensation-fields.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+	compensationFromApplication,
+	compensationToPayload,
+	EMPTY_COMPENSATION,
+} from "./compensation-fields";
+
+describe("compensationToPayload", () => {
+	it("returns all-null payload from empty form state", () => {
+		expect(compensationToPayload(EMPTY_COMPENSATION)).toEqual({
+			salaryMin: null,
+			salaryMax: null,
+			salaryCurrency: null,
+			workSetup: null,
+			locationAddress: null,
+			companyWebsite: null,
+			contactName: null,
+			contactEmail: null,
+			contactPhone: null,
+		});
+	});
+
+	it("converts numeric strings to numbers", () => {
+		const out = compensationToPayload({
+			...EMPTY_COMPENSATION,
+			salaryMin: "150000",
+			salaryMax: "200000",
+		});
+		expect(out.salaryMin).toBe(150_000);
+		expect(out.salaryMax).toBe(200_000);
+		expect(out.salaryCurrency).toBe("PHP");
+	});
+
+	it("clears currency when no salary value is set", () => {
+		const out = compensationToPayload({
+			...EMPTY_COMPENSATION,
+			salaryCurrency: "USD",
+		});
+		expect(out.salaryCurrency).toBeNull();
+	});
+
+	it("trims and nulls empty optional strings", () => {
+		const out = compensationToPayload({
+			...EMPTY_COMPENSATION,
+			locationAddress: "   ",
+			companyWebsite: "",
+			contactName: "  Jane  ",
+		});
+		expect(out.locationAddress).toBeNull();
+		expect(out.companyWebsite).toBeNull();
+		expect(out.contactName).toBe("Jane");
+	});
+
+	it("passes workSetup through unchanged", () => {
+		const out = compensationToPayload({ ...EMPTY_COMPENSATION, workSetup: "HYBRID" });
+		expect(out.workSetup).toBe("HYBRID");
+	});
+});
+
+describe("compensationFromApplication", () => {
+	it("hydrates from a fully-populated application", () => {
+		const result = compensationFromApplication({
+			salaryMin: 150_000,
+			salaryMax: 200_000,
+			salaryCurrency: "PHP",
+			workSetup: "ONSITE",
+			locationAddress: "BGC, Taguig",
+			companyWebsite: "https://example.com",
+			contactName: "Jane",
+			contactEmail: "jane@example.com",
+			contactPhone: "+63-900-000-0000",
+		});
+		expect(result.salaryMin).toBe("150000");
+		expect(result.salaryMax).toBe("200000");
+		expect(result.workSetup).toBe("ONSITE");
+		expect(result.locationAddress).toBe("BGC, Taguig");
+	});
+
+	it("falls back to safe defaults for missing/null fields", () => {
+		const result = compensationFromApplication({});
+		expect(result.salaryMin).toBe("");
+		expect(result.salaryMax).toBe("");
+		expect(result.salaryCurrency).toBe("PHP");
+		expect(result.workSetup).toBe("");
+	});
+});

--- a/src/components/applications/compensation-fields.test.ts
+++ b/src/components/applications/compensation-fields.test.ts
@@ -76,11 +76,18 @@ describe("compensationFromApplication", () => {
 		expect(result.locationAddress).toBe("BGC, Taguig");
 	});
 
-	it("falls back to safe defaults for missing/null fields", () => {
+	it("preserves null currency on hydrate (does not silently default to PHP)", () => {
 		const result = compensationFromApplication({});
 		expect(result.salaryMin).toBe("");
 		expect(result.salaryMax).toBe("");
-		expect(result.salaryCurrency).toBe("PHP");
+		expect(result.salaryCurrency).toBe("");
 		expect(result.workSetup).toBe("");
+	});
+
+	it("round-trips a record with null currency back to null on save", () => {
+		const hydrated = compensationFromApplication({ salaryMin: 150_000, salaryCurrency: null });
+		const payload = compensationToPayload(hydrated);
+		expect(payload.salaryMin).toBe(150_000);
+		expect(payload.salaryCurrency).toBeNull();
 	});
 });

--- a/src/components/applications/compensation-fields.tsx
+++ b/src/components/applications/compensation-fields.tsx
@@ -14,10 +14,18 @@ import type { WorkSetup } from "@/generated/prisma/enums";
 
 export const CURRENCIES = ["PHP", "USD", "EUR", "SGD", "AUD", "GBP", "JPY"] as const;
 
+// Single source of truth for work-setup human labels — used by the form select,
+// the detail panel, and the list-card pill.
+export const WORK_SETUP_LABELS: Record<WorkSetup, string> = {
+	REMOTE: "Remote",
+	HYBRID: "Hybrid",
+	ONSITE: "Onsite",
+};
+
 export const WORK_SETUP_OPTIONS: { value: WorkSetup; label: string }[] = [
 	{ value: "REMOTE", label: "Remote (Work from home)" },
-	{ value: "HYBRID", label: "Hybrid" },
-	{ value: "ONSITE", label: "Onsite" },
+	{ value: "HYBRID", label: WORK_SETUP_LABELS.HYBRID },
+	{ value: "ONSITE", label: WORK_SETUP_LABELS.ONSITE },
 ];
 
 export type CompensationValue = {
@@ -60,7 +68,10 @@ export function compensationFromApplication(app: ApplicationLike): CompensationV
 	return {
 		salaryMin: app.salaryMin != null ? String(app.salaryMin) : "",
 		salaryMax: app.salaryMax != null ? String(app.salaryMax) : "",
-		salaryCurrency: app.salaryCurrency ?? "PHP",
+		// Preserve null-ness on hydrate so a no-op edit doesn't silently mutate
+		// a null currency to "PHP". `EMPTY_COMPENSATION` still defaults to "PHP"
+		// for the *new* form.
+		salaryCurrency: app.salaryCurrency ?? "",
 		workSetup: app.workSetup ?? "",
 		locationAddress: app.locationAddress ?? "",
 		companyWebsite: app.companyWebsite ?? "",
@@ -165,21 +176,32 @@ export function CompensationFields({ value, onChange }: Props) {
 
 				<div className="space-y-2">
 					<Label htmlFor="work-setup">Work setup</Label>
-					<Select
-						value={value.workSetup}
-						onValueChange={(v) => update("workSetup", (v ?? "") as "" | WorkSetup)}
-					>
-						<SelectTrigger className="w-full sm:w-[260px]">
-							<SelectValue placeholder="Not specified" />
-						</SelectTrigger>
-						<SelectContent>
-							{WORK_SETUP_OPTIONS.map((o) => (
-								<SelectItem key={o.value} value={o.value}>
-									{o.label}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
+					<div className="flex items-center gap-2">
+						<Select
+							value={value.workSetup}
+							onValueChange={(v) => update("workSetup", (v ?? "") as "" | WorkSetup)}
+						>
+							<SelectTrigger className="w-full sm:w-[260px]">
+								<SelectValue placeholder="Not specified" />
+							</SelectTrigger>
+							<SelectContent>
+								{WORK_SETUP_OPTIONS.map((o) => (
+									<SelectItem key={o.value} value={o.value}>
+										{o.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						{value.workSetup ? (
+							<button
+								type="button"
+								onClick={() => update("workSetup", "")}
+								className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+							>
+								Clear
+							</button>
+						) : null}
+					</div>
 				</div>
 
 				{showLocation ? (

--- a/src/components/applications/compensation-fields.tsx
+++ b/src/components/applications/compensation-fields.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import type { WorkSetup } from "@/generated/prisma/enums";
+
+export const CURRENCIES = ["PHP", "USD", "EUR", "SGD", "AUD", "GBP", "JPY"] as const;
+
+export const WORK_SETUP_OPTIONS: { value: WorkSetup; label: string }[] = [
+	{ value: "REMOTE", label: "Remote (Work from home)" },
+	{ value: "HYBRID", label: "Hybrid" },
+	{ value: "ONSITE", label: "Onsite" },
+];
+
+export type CompensationValue = {
+	salaryMin: string;
+	salaryMax: string;
+	salaryCurrency: string;
+	workSetup: "" | WorkSetup;
+	locationAddress: string;
+	companyWebsite: string;
+	contactName: string;
+	contactEmail: string;
+	contactPhone: string;
+};
+
+export const EMPTY_COMPENSATION: CompensationValue = {
+	salaryMin: "",
+	salaryMax: "",
+	salaryCurrency: "PHP",
+	workSetup: "",
+	locationAddress: "",
+	companyWebsite: "",
+	contactName: "",
+	contactEmail: "",
+	contactPhone: "",
+};
+
+type ApplicationLike = {
+	salaryMin?: number | null;
+	salaryMax?: number | null;
+	salaryCurrency?: string | null;
+	workSetup?: WorkSetup | null;
+	locationAddress?: string | null;
+	companyWebsite?: string | null;
+	contactName?: string | null;
+	contactEmail?: string | null;
+	contactPhone?: string | null;
+};
+
+export function compensationFromApplication(app: ApplicationLike): CompensationValue {
+	return {
+		salaryMin: app.salaryMin != null ? String(app.salaryMin) : "",
+		salaryMax: app.salaryMax != null ? String(app.salaryMax) : "",
+		salaryCurrency: app.salaryCurrency ?? "PHP",
+		workSetup: app.workSetup ?? "",
+		locationAddress: app.locationAddress ?? "",
+		companyWebsite: app.companyWebsite ?? "",
+		contactName: app.contactName ?? "",
+		contactEmail: app.contactEmail ?? "",
+		contactPhone: app.contactPhone ?? "",
+	};
+}
+
+export function compensationToPayload(v: CompensationValue) {
+	const min = v.salaryMin.trim() ? Number(v.salaryMin) : null;
+	const max = v.salaryMax.trim() ? Number(v.salaryMax) : null;
+	return {
+		salaryMin: Number.isFinite(min) ? min : null,
+		salaryMax: Number.isFinite(max) ? max : null,
+		salaryCurrency: min != null || max != null ? v.salaryCurrency || null : null,
+		workSetup: v.workSetup || null,
+		locationAddress: v.locationAddress.trim() || null,
+		companyWebsite: v.companyWebsite.trim() || null,
+		contactName: v.contactName.trim() || null,
+		contactEmail: v.contactEmail.trim() || null,
+		contactPhone: v.contactPhone.trim() || null,
+	};
+}
+
+type Props = {
+	value: CompensationValue;
+	onChange: (next: CompensationValue) => void;
+};
+
+export function CompensationFields({ value, onChange }: Props) {
+	const update = <K extends keyof CompensationValue>(key: K, v: CompensationValue[K]) => {
+		onChange({ ...value, [key]: v });
+	};
+
+	const showLocation = value.workSetup === "HYBRID" || value.workSetup === "ONSITE";
+	const minVal = Number(value.salaryMin);
+	const maxVal = Number(value.salaryMax);
+	const rangeInvalid =
+		value.salaryMin !== "" &&
+		value.salaryMax !== "" &&
+		Number.isFinite(minVal) &&
+		Number.isFinite(maxVal) &&
+		maxVal < minVal;
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Compensation & Logistics</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<div className="space-y-2">
+					<Label>Monthly salary range</Label>
+					<div className="grid gap-2 sm:grid-cols-[1fr_1fr_120px]">
+						<Input
+							type="number"
+							inputMode="numeric"
+							min="0"
+							placeholder="Min"
+							value={value.salaryMin}
+							onChange={(e) => update("salaryMin", e.target.value)}
+						/>
+						<Input
+							type="number"
+							inputMode="numeric"
+							min="0"
+							placeholder="Max"
+							value={value.salaryMax}
+							onChange={(e) => update("salaryMax", e.target.value)}
+							aria-invalid={rangeInvalid}
+						/>
+						<Select
+							value={value.salaryCurrency}
+							onValueChange={(v) => v && update("salaryCurrency", v)}
+						>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{CURRENCIES.map((c) => (
+									<SelectItem key={c} value={c}>
+										{c}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					{rangeInvalid ? (
+						<p className="text-xs text-destructive">
+							Max salary must be greater than or equal to min salary.
+						</p>
+					) : (
+						<p className="text-xs text-muted-foreground">Per month. Leave blank if undisclosed.</p>
+					)}
+				</div>
+
+				<div className="space-y-2">
+					<Label htmlFor="work-setup">Work setup</Label>
+					<Select
+						value={value.workSetup}
+						onValueChange={(v) => update("workSetup", (v ?? "") as "" | WorkSetup)}
+					>
+						<SelectTrigger className="w-full sm:w-[260px]">
+							<SelectValue placeholder="Not specified" />
+						</SelectTrigger>
+						<SelectContent>
+							{WORK_SETUP_OPTIONS.map((o) => (
+								<SelectItem key={o.value} value={o.value}>
+									{o.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				{showLocation ? (
+					<div className="space-y-2">
+						<Label htmlFor="location-address">Location address</Label>
+						<Input
+							id="location-address"
+							placeholder="City, district, or office address"
+							value={value.locationAddress}
+							onChange={(e) => update("locationAddress", e.target.value)}
+						/>
+					</div>
+				) : null}
+
+				<div className="space-y-2">
+					<Label htmlFor="company-website">Company website</Label>
+					<Input
+						id="company-website"
+						type="url"
+						placeholder="https://..."
+						value={value.companyWebsite}
+						onChange={(e) => update("companyWebsite", e.target.value)}
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<Label>Contact person</Label>
+					<div className="grid gap-2 sm:grid-cols-3">
+						<Input
+							placeholder="Name"
+							value={value.contactName}
+							onChange={(e) => update("contactName", e.target.value)}
+						/>
+						<Input
+							type="email"
+							placeholder="Email"
+							value={value.contactEmail}
+							onChange={(e) => update("contactEmail", e.target.value)}
+						/>
+						<Input
+							type="tel"
+							placeholder="Phone"
+							value={value.contactPhone}
+							onChange={(e) => update("contactPhone", e.target.value)}
+						/>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/applications/compensation-fields.tsx
+++ b/src/components/applications/compensation-fields.tsx
@@ -113,17 +113,20 @@ export function CompensationFields({ value, onChange }: Props) {
 			</CardHeader>
 			<CardContent className="space-y-4">
 				<div className="space-y-2">
-					<Label>Monthly salary range</Label>
+					<Label htmlFor="salary-min">Monthly salary range</Label>
 					<div className="grid gap-2 sm:grid-cols-[1fr_1fr_120px]">
 						<Input
+							id="salary-min"
 							type="number"
 							inputMode="numeric"
 							min="0"
 							placeholder="Min"
 							value={value.salaryMin}
 							onChange={(e) => update("salaryMin", e.target.value)}
+							aria-describedby="salary-hint"
 						/>
 						<Input
+							id="salary-max"
 							type="number"
 							inputMode="numeric"
 							min="0"
@@ -131,12 +134,13 @@ export function CompensationFields({ value, onChange }: Props) {
 							value={value.salaryMax}
 							onChange={(e) => update("salaryMax", e.target.value)}
 							aria-invalid={rangeInvalid}
+							aria-describedby="salary-hint"
 						/>
 						<Select
 							value={value.salaryCurrency}
 							onValueChange={(v) => v && update("salaryCurrency", v)}
 						>
-							<SelectTrigger>
+							<SelectTrigger aria-label="Currency">
 								<SelectValue />
 							</SelectTrigger>
 							<SelectContent>
@@ -149,11 +153,13 @@ export function CompensationFields({ value, onChange }: Props) {
 						</Select>
 					</div>
 					{rangeInvalid ? (
-						<p className="text-xs text-destructive">
+						<p id="salary-hint" className="text-xs text-destructive">
 							Max salary must be greater than or equal to min salary.
 						</p>
 					) : (
-						<p className="text-xs text-muted-foreground">Per month. Leave blank if undisclosed.</p>
+						<p id="salary-hint" className="text-xs text-muted-foreground">
+							Per month. Leave blank if undisclosed.
+						</p>
 					)}
 				</div>
 
@@ -199,28 +205,34 @@ export function CompensationFields({ value, onChange }: Props) {
 					/>
 				</div>
 
-				<div className="space-y-2">
-					<Label>Contact person</Label>
+				<fieldset className="space-y-2">
+					<legend className="text-sm font-medium">Contact person</legend>
 					<div className="grid gap-2 sm:grid-cols-3">
 						<Input
+							id="contact-name"
+							aria-label="Contact name"
 							placeholder="Name"
 							value={value.contactName}
 							onChange={(e) => update("contactName", e.target.value)}
 						/>
 						<Input
+							id="contact-email"
+							aria-label="Contact email"
 							type="email"
 							placeholder="Email"
 							value={value.contactEmail}
 							onChange={(e) => update("contactEmail", e.target.value)}
 						/>
 						<Input
+							id="contact-phone"
+							aria-label="Contact phone"
 							type="tel"
 							placeholder="Phone"
 							value={value.contactPhone}
 							onChange={(e) => update("contactPhone", e.target.value)}
 						/>
 					</div>
-				</div>
+				</fieldset>
 			</CardContent>
 		</Card>
 	);

--- a/src/components/applications/job-details-panel.tsx
+++ b/src/components/applications/job-details-panel.tsx
@@ -13,10 +13,10 @@ const WORK_SETUP_LABELS: Record<NonNullable<JobApplication["workSetup"]>, string
 function formatSalary(min: number | null, max: number | null, currency: string | null) {
 	if (min == null && max == null) return null;
 	const fmt = (n: number) => n.toLocaleString();
-	const cur = currency ?? "PHP";
-	if (min != null && max != null) return `${cur} ${fmt(min)} – ${fmt(max)} / month`;
-	if (min != null) return `${cur} ${fmt(min)}+ / month`;
-	return `Up to ${cur} ${fmt(max!)} / month`;
+	const prefix = currency?.trim() ? `${currency.trim()} ` : "";
+	if (min != null && max != null) return `${prefix}${fmt(min)} – ${fmt(max)} / month`;
+	if (min != null) return `${prefix}${fmt(min)}+ / month`;
+	return `Up to ${prefix}${fmt(max!)} / month`;
 }
 
 function ensureProtocol(url: string) {

--- a/src/components/applications/job-details-panel.tsx
+++ b/src/components/applications/job-details-panel.tsx
@@ -3,12 +3,7 @@
 import { Banknote, Briefcase, Globe, Mail, MapPin, Phone, User as UserIcon } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { JobApplication } from "@/generated/prisma/client";
-
-const WORK_SETUP_LABELS: Record<NonNullable<JobApplication["workSetup"]>, string> = {
-	REMOTE: "Remote",
-	HYBRID: "Hybrid",
-	ONSITE: "Onsite",
-};
+import { WORK_SETUP_LABELS } from "./compensation-fields";
 
 function formatSalary(min: number | null, max: number | null, currency: string | null) {
 	if (min == null && max == null) return null;

--- a/src/components/applications/job-details-panel.tsx
+++ b/src/components/applications/job-details-panel.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Banknote, Briefcase, Globe, Mail, MapPin, Phone, User as UserIcon } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { JobApplication } from "@/generated/prisma/client";
+
+const WORK_SETUP_LABELS: Record<NonNullable<JobApplication["workSetup"]>, string> = {
+	REMOTE: "Remote",
+	HYBRID: "Hybrid",
+	ONSITE: "Onsite",
+};
+
+function formatSalary(min: number | null, max: number | null, currency: string | null) {
+	if (min == null && max == null) return null;
+	const fmt = (n: number) => n.toLocaleString();
+	const cur = currency ?? "PHP";
+	if (min != null && max != null) return `${cur} ${fmt(min)} – ${fmt(max)} / month`;
+	if (min != null) return `${cur} ${fmt(min)}+ / month`;
+	return `Up to ${cur} ${fmt(max!)} / month`;
+}
+
+function ensureProtocol(url: string) {
+	return /^https?:\/\//i.test(url) ? url : `https://${url}`;
+}
+
+export function JobDetailsPanel({ application }: { application: JobApplication }) {
+	const salary = formatSalary(
+		application.salaryMin,
+		application.salaryMax,
+		application.salaryCurrency,
+	);
+	const setupLabel = application.workSetup ? WORK_SETUP_LABELS[application.workSetup] : null;
+	const hasContact =
+		application.contactName || application.contactEmail || application.contactPhone;
+
+	const hasAny =
+		salary || setupLabel || application.locationAddress || application.companyWebsite || hasContact;
+
+	if (!hasAny) return null;
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Job Details</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-3 text-sm">
+				{salary ? (
+					<DetailRow icon={<Banknote className="h-3.5 w-3.5" />} label="Salary">
+						{salary}
+					</DetailRow>
+				) : null}
+				{setupLabel ? (
+					<DetailRow icon={<Briefcase className="h-3.5 w-3.5" />} label="Work setup">
+						<span className="rounded-md bg-primary/10 px-2 py-0.5 text-xs text-primary">
+							{setupLabel}
+						</span>
+					</DetailRow>
+				) : null}
+				{application.locationAddress ? (
+					<DetailRow icon={<MapPin className="h-3.5 w-3.5" />} label="Location">
+						{application.locationAddress}
+					</DetailRow>
+				) : null}
+				{application.companyWebsite ? (
+					<DetailRow icon={<Globe className="h-3.5 w-3.5" />} label="Website">
+						<a
+							href={ensureProtocol(application.companyWebsite)}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-primary transition-colors hover:underline"
+						>
+							{application.companyWebsite}
+						</a>
+					</DetailRow>
+				) : null}
+				{hasContact ? (
+					<div className="space-y-1.5 border-t border-border pt-3">
+						<p className="text-xs font-medium text-muted-foreground">Contact person</p>
+						{application.contactName ? (
+							<DetailRow icon={<UserIcon className="h-3.5 w-3.5" />} label="Name">
+								{application.contactName}
+							</DetailRow>
+						) : null}
+						{application.contactEmail ? (
+							<DetailRow icon={<Mail className="h-3.5 w-3.5" />} label="Email">
+								<a
+									href={`mailto:${application.contactEmail}`}
+									className="text-primary transition-colors hover:underline"
+								>
+									{application.contactEmail}
+								</a>
+							</DetailRow>
+						) : null}
+						{application.contactPhone ? (
+							<DetailRow icon={<Phone className="h-3.5 w-3.5" />} label="Phone">
+								<a
+									href={`tel:${application.contactPhone}`}
+									className="text-primary transition-colors hover:underline"
+								>
+									{application.contactPhone}
+								</a>
+							</DetailRow>
+						) : null}
+					</div>
+				) : null}
+			</CardContent>
+		</Card>
+	);
+}
+
+function DetailRow({
+	icon,
+	label,
+	children,
+}: {
+	icon: React.ReactNode;
+	label: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="flex items-center gap-3">
+			<span className="flex w-24 shrink-0 items-center gap-1.5 text-muted-foreground">
+				{icon}
+				{label}
+			</span>
+			<span className="flex-1">{children}</span>
+		</div>
+	);
+}

--- a/src/lib/validations.test.ts
+++ b/src/lib/validations.test.ts
@@ -85,6 +85,49 @@ describe("createApplicationSchema — compensation", () => {
 		expect(result.success).toBe(false);
 	});
 
+	it("rejects javascript: URLs on companyWebsite (XSS guard)", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			companyWebsite: "javascript:alert(1)",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects data: URLs on companyWebsite", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			companyWebsite: "data:text/html,<script>alert(1)</script>",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects ftp: URLs on companyWebsite", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			companyWebsite: "ftp://example.com/file",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("accepts valid http(s) URLs on companyWebsite", () => {
+		expect(
+			createApplicationSchema.safeParse({ ...baseValid, companyWebsite: "http://example.com" })
+				.success,
+		).toBe(true);
+		expect(
+			createApplicationSchema.safeParse({ ...baseValid, companyWebsite: "https://example.com" })
+				.success,
+		).toBe(true);
+	});
+
+	it("rejects javascript: URLs on sourceUrl", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			sourceUrl: "javascript:alert(1)",
+		});
+		expect(result.success).toBe(false);
+	});
+
 	it("rejects malformed contact email", () => {
 		const result = createApplicationSchema.safeParse({
 			...baseValid,

--- a/src/lib/validations.test.ts
+++ b/src/lib/validations.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { createApplicationSchema, updateApplicationSchema } from "./validations";
+
+const baseValid = {
+	title: "Senior Engineer",
+	company: "Acme",
+	rawDescription: "Long enough description to pass min(10).",
+};
+
+describe("createApplicationSchema — compensation", () => {
+	it("accepts the application without any compensation fields", () => {
+		expect(createApplicationSchema.safeParse(baseValid).success).toBe(true);
+	});
+
+	it("accepts a valid salary range", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			salaryMin: 100_000,
+			salaryMax: 200_000,
+			salaryCurrency: "PHP",
+			workSetup: "HYBRID",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects when salaryMax is less than salaryMin", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			salaryMin: 200_000,
+			salaryMax: 100_000,
+		});
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		const issue = result.error.issues.find((i) => i.path.join(".") === "salaryMax");
+		expect(issue?.message).toMatch(/greater than or equal/);
+	});
+
+	it("allows salaryMax === salaryMin", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			salaryMin: 150_000,
+			salaryMax: 150_000,
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects salary values that exceed Postgres INTEGER max", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			salaryMin: 99_999_999_999,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects negative salary", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			salaryMin: -1,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects an invalid workSetup value", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			workSetup: "ON_THE_MOON",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("accepts empty string for optional URL/email fields", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			companyWebsite: "",
+			contactEmail: "",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects malformed URL on companyWebsite", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			companyWebsite: "not a url",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects malformed contact email", () => {
+		const result = createApplicationSchema.safeParse({
+			...baseValid,
+			contactEmail: "nope",
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("updateApplicationSchema — compensation", () => {
+	it("accepts a partial patch with only one new field", () => {
+		const result = updateApplicationSchema.safeParse({ workSetup: "REMOTE" });
+		expect(result.success).toBe(true);
+	});
+
+	it("enforces salary range refinement on partial patches", () => {
+		const result = updateApplicationSchema.safeParse({
+			salaryMin: 300_000,
+			salaryMax: 100_000,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("allows clearing fields with null where the schema is nullable", () => {
+		const result = updateApplicationSchema.safeParse({
+			salaryMin: null,
+			salaryMax: null,
+			workSetup: null,
+		});
+		expect(result.success).toBe(true);
+	});
+});

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -19,26 +19,66 @@ export const cvUploadSchema = z.object({
 
 // ─── Applications ─────────────────────────────────────────────────────
 
-export const createApplicationSchema = z.object({
-	title: z.string().min(1, "Job title is required"),
-	company: z.string().min(1, "Company name is required"),
-	sourceUrl: z.string().url().optional().or(z.literal("")),
-	rawDescription: z.string().min(10, "Job description is required"),
-	notes: z.string().optional(),
-});
+const workSetupEnum = z.enum(["REMOTE", "HYBRID", "ONSITE"]);
 
-export const updateApplicationSchema = z.object({
-	title: z.string().min(1).optional(),
-	company: z.string().min(1).optional(),
-	rawDescription: z.string().min(10).optional(),
-	status: z
-		.enum(["DRAFT", "ANALYZED", "TAILORED", "APPLIED", "REJECTED", "INTERVIEW", "OFFER"])
-		.optional(),
-	notes: z.string().optional(),
-	tailoredCVEdited: z.string().optional(),
-	coverLetter: z.string().optional(),
-	appliedAt: z.string().datetime().optional().nullable(),
-});
+const optionalUrl = z.string().url().optional().or(z.literal(""));
+const optionalEmail = z.string().email().optional().or(z.literal(""));
+
+const compensationFields = {
+	salaryMin: z.number().int().nonnegative().optional().nullable(),
+	salaryMax: z.number().int().nonnegative().optional().nullable(),
+	salaryCurrency: z.string().trim().min(2).max(8).optional().or(z.literal("")),
+	workSetup: workSetupEnum.optional().nullable(),
+	locationAddress: z.string().trim().max(500).optional(),
+	companyWebsite: optionalUrl,
+	contactName: z.string().trim().max(200).optional(),
+	contactEmail: optionalEmail,
+	contactPhone: z.string().trim().max(50).optional(),
+};
+
+const salaryRangeRefinement = (
+	data: { salaryMin?: number | null; salaryMax?: number | null },
+	ctx: z.RefinementCtx,
+) => {
+	if (
+		typeof data.salaryMin === "number" &&
+		typeof data.salaryMax === "number" &&
+		data.salaryMax < data.salaryMin
+	) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["salaryMax"],
+			message: "Max salary must be greater than or equal to min salary",
+		});
+	}
+};
+
+export const createApplicationSchema = z
+	.object({
+		title: z.string().min(1, "Job title is required"),
+		company: z.string().min(1, "Company name is required"),
+		sourceUrl: optionalUrl,
+		rawDescription: z.string().min(10, "Job description is required"),
+		notes: z.string().optional(),
+		...compensationFields,
+	})
+	.superRefine(salaryRangeRefinement);
+
+export const updateApplicationSchema = z
+	.object({
+		title: z.string().min(1).optional(),
+		company: z.string().min(1).optional(),
+		rawDescription: z.string().min(10).optional(),
+		status: z
+			.enum(["DRAFT", "ANALYZED", "TAILORED", "APPLIED", "REJECTED", "INTERVIEW", "OFFER"])
+			.optional(),
+		notes: z.string().optional(),
+		tailoredCVEdited: z.string().optional(),
+		coverLetter: z.string().optional(),
+		appliedAt: z.string().datetime().optional().nullable(),
+		...compensationFields,
+	})
+	.superRefine(salaryRangeRefinement);
 
 export const bulkStatusUpdateSchema = z.object({
 	ids: z.array(z.string().min(1)).min(1),

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -24,9 +24,20 @@ const workSetupEnum = z.enum(["REMOTE", "HYBRID", "ONSITE"]);
 const optionalUrl = z.string().url().optional().or(z.literal(""));
 const optionalEmail = z.string().email().optional().or(z.literal(""));
 
+// Postgres INTEGER is 4 bytes signed (max 2,147,483,647). Stay below to avoid
+// 500s from values that pass zod but blow up on Prisma write.
+const PG_INT_MAX = 2_147_483_647;
+const salaryAmount = z
+	.number()
+	.int()
+	.nonnegative()
+	.max(PG_INT_MAX, "Salary value is too large")
+	.optional()
+	.nullable();
+
 const compensationFields = {
-	salaryMin: z.number().int().nonnegative().optional().nullable(),
-	salaryMax: z.number().int().nonnegative().optional().nullable(),
+	salaryMin: salaryAmount,
+	salaryMax: salaryAmount,
 	salaryCurrency: z.string().trim().min(2).max(8).optional().or(z.literal("")),
 	workSetup: workSetupEnum.optional().nullable(),
 	locationAddress: z.string().trim().max(500).optional(),

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -21,7 +21,14 @@ export const cvUploadSchema = z.object({
 
 const workSetupEnum = z.enum(["REMOTE", "HYBRID", "ONSITE"]);
 
-const optionalUrl = z.string().url().optional().or(z.literal(""));
+// Block non-http(s) schemes (javascript:, data:, ftp: …) so values can be
+// safely rendered as anchor hrefs without an XSS surface.
+const optionalUrl = z
+	.string()
+	.url()
+	.refine((url) => /^https?:\/\//i.test(url), "Only http and https URLs are allowed")
+	.optional()
+	.or(z.literal(""));
 const optionalEmail = z.string().email().optional().or(z.literal(""));
 
 // Postgres INTEGER is 4 bytes signed (max 2,147,483,647). Stay below to avoid


### PR DESCRIPTION
Phase 1 of #23 — capture more context per job application. All new fields are optional.

## Summary
- New columns on `JobApplication`: `salaryMin`, `salaryMax`, `salaryCurrency`, `workSetup` (`WorkSetup` enum: `REMOTE` | `HYBRID` | `ONSITE`), `locationAddress`, `companyWebsite`, `contactName`, `contactEmail`, `contactPhone`
- Shared `CompensationFields` component used on `/applications/new` and `/applications/[id]/edit`; location field only renders when work setup is `HYBRID` or `ONSITE`
- `JobDetailsPanel` surfaces the new fields read-only at the top of the detail page's Description tab; `ApplicationCard` shows a compact salary chip and work-setup pill

## Schema
Migration `20260427190945_add_application_compensation_and_work_setup` creates the `WorkSetup` enum and adds the 9 new columns. Local dev DB applied via `prisma db push` (matches the project's `db:sync` workflow); the migration SQL is in the folder for production/CI use.

## Validation
`createApplicationSchema` and `updateApplicationSchema` now share a `compensationFields` block plus a `superRefine` that enforces `salaryMax >= salaryMin` when both are set. Empty strings on optional URL/email/text fields are normalized to `null` server-side on PATCH.

## Out of scope (Phase 2, separate PR)
- Kanban board view at `/applications`
- View toggle (list/kanban) persisted per-user
- `@dnd-kit` deps (still pending approval per #23)

## Test plan
- [ ] `pnpm dev` and visit `/applications/new` — verify the new "Compensation & Logistics" card is present
- [ ] Filling all new fields then submitting creates an application with the values stored
- [ ] Switching work setup to `HYBRID`/`ONSITE` reveals the location field; `REMOTE` hides it
- [ ] `/applications/[id]/edit` — fields hydrate from existing record and round-trip on save
- [ ] `/applications/[id]` — Job Details panel renders salary, work setup, address, linkified website, and contact block (mailto/tel links)
- [ ] List view — cards show salary chip + setup pill when set, render cleanly when not
- [ ] Existing applications without new fields still display correctly (graceful nulls)
- [ ] Salary refinement: setting min=200000, max=100000 shows the inline error and blocks submit

## Verified
- `pnpm exec tsc --noEmit` clean
- `pnpm exec biome check` clean on touched files
- Direct DB round-trip (`INSERT`/`SELECT`) confirms columns and `WorkSetup` enum work end-to-end

Closes part of #23 (Phase 1 only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compensation fields for applications: salary min/max, currency, and work-setup (Remote/Hybrid/On-site)
  * Added location address, company website, and contact person (name, email, phone)
  * Job Details panel and application cards display salary and work-setup info

* **Improvements**
  * Client/server validation preventing salaryMax < salaryMin; salary fields respect DB-safe integer bounds
  * Address shown conditionally for Hybrid/On-site; empty text normalized to null

* **Tests**
  * New unit tests for compensation handling, validation, and empty-string normalization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->